### PR TITLE
chore: bump pyimouapi to 1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [1.2.8]
+### Changed
+- Bump pyimouapi to 1.2.8 (batch property polling via getIotDeviceDetailInfo)
+
 ## [1.2.7]
 ### Added
 - Contributor governance: PR template, CI (lint/test/hassfest/HACS), CODEOWNERS, and CONTRIBUTING guide

--- a/custom_components/imou_life/manifest.json
+++ b/custom_components/imou_life/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/issues",
   "quality_scale": "bronze",
-  "requirements": ["pyimouapi==1.2.7"],
-  "version": "1.2.7"
+  "requirements": ["pyimouapi==1.2.8"],
+  "version": "1.2.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ prerelease = "allow"
 [dependency-groups]
 dev = [
   "homeassistant==2025.1.4",
-  "pyimouapi==1.2.7",
+  "pyimouapi==1.2.8",
   "pytest-homeassistant-custom-component==0.13.205",
   "pytest-asyncio>=0.24.0",
   "pytest-timeout>=2.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1237,7 +1237,7 @@ dev = [
     { name = "codespell", specifier = ">=2.3.0" },
     { name = "homeassistant", specifier = "==2025.1.4" },
     { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pyimouapi", specifier = "==1.2.7" },
+    { name = "pyimouapi", specifier = "==1.2.8" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.205" },
     { name = "pytest-timeout", specifier = ">=2.3.0" },
@@ -1915,15 +1915,15 @@ wheels = [
 
 [[package]]
 name = "pyimouapi"
-version = "1.2.7"
+version = "1.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "simpleeval" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/79/cb9eb490e4b18d8bd300e4d4cde05cd5603787406957a5a766b1a5cb4ff1/pyimouapi-1.2.7.tar.gz", hash = "sha256:e4c8574e084490856d09e64ca6c75cdc0ec740edb2272d3215883e2d23826b4a", size = 19269, upload-time = "2026-06-02T11:51:50.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/90/b1a3e544eda50252641c54f2758bfd04445531d92aaf8fe999ac84ccdaef/pyimouapi-1.2.8.tar.gz", hash = "sha256:8b50fcf35e10f2df59313d93f870375397ae46aedbe787fbf3d0f20e23af8bf9", size = 22445, upload-time = "2026-06-12T03:24:22.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/85/878e9c2edda04c51b46dcea1eae140185de576bfbb4924b0db708505ca54/pyimouapi-1.2.7-py3-none-any.whl", hash = "sha256:2bcfaff98db5ce596a81f233d31e4555bd633c83e72c83f0b15bf88ba896db18", size = 19571, upload-time = "2026-06-02T11:51:49.466Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/3285ecddacf23418d1ddf745b5660339527ff2954d1c87c9cf6d949deb66/pyimouapi-1.2.8-py3-none-any.whl", hash = "sha256:12d5aefd19b31898d5b776345f7effb2f33270d8b40276d717847045c51a2232", size = 20621, upload-time = "2026-06-12T03:24:21.667Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Bump `pyimouapi` runtime dependency to **1.2.8** in `manifest.json`
- Align `pyproject.toml` dev dependency and `uv.lock`
- Release integration version **1.2.8** with CHANGELOG entry

Depends on [Py-Imou-Open-Api#7](https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api/pull/7) (merged; `pyimouapi` 1.2.8 on PyPI).

## Test plan

- [x] `script/lint-check` passes
- [x] `script/test` — 3 passed
- [x] Manual HA verification with real Imou devices after HACS/install update