### PR TITLE
chore: auto-trigger CI on fork PRs and ready_for_review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,6 +21,7 @@ Fixes #
 - [ ] If `manifest.json` changed: version bumped and `CHANGELOG.md` updated.
 - [ ] If user-facing strings changed: `translations/` updated.
 - [ ] If dependencies changed: version pin updated with changelog link in this description.
+- [ ] GitHub Actions checks are green (CI runs automatically on fork PRs; mark **Ready for review** if this was a draft).
 
 ### AI-assisted contributions
 

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,13 @@ This package is installed for end users via `manifest.json` and for local/CI tes
 3. Tag on `main`: `git tag vX.Y.Z && git push origin vX.Y.Z`
 4. The release workflow publishes the HACS zip asset.
 
+## CI on pull requests
+
+- **Fork PRs:** CI (Lint, Test, Hassfest, Manifest, etc.) runs automatically when a PR is opened or updated. Maintainers do **not** need to click "Approve and run workflows" on fork PRs (see **Settings → Actions → Fork pull request workflows**).
+- **Draft PRs:** Mark the PR **Ready for review** (or push new commits) to trigger CI. Workflows listen for `ready_for_review` and `synchronize`.
+- **HACS** still runs only on PRs in the canonical repository `Imou-OpenPlatform/Imou-Home-Assistant`.
+- **Merge** still requires one maintainer approval and all required status checks (see Branch protection below).
+
 ## Branch protection (maintainers)
 
 Configure in GitHub → **Settings** → **Branches** → rule for `main`:
@@ -131,7 +138,10 @@ Configure in GitHub → **Settings** → **Branches** → rule for `main`:
 - Require status checks: **Lint**, **Spell**, **YAML**, **Hassfest**, **HACS**, **Manifest**, **Test**
 - Dismiss stale approvals when new commits are pushed
 
-**HACS** runs only on the canonical repository `Imou-OpenPlatform/Imou-Home-Assistant`; fork PRs may skip it.
+Configure in GitHub → **Settings** → **Actions** → **General** → **Fork pull request workflows**:
+
+- Enable **Run workflows from fork pull requests**
+- Choose the least restrictive approval option (e.g. **first-time contributors new to GitHub** only). Public repositories cannot disable fork workflow approval entirely via API; established fork contributors typically run CI automatically after their first approved workflow run.
 
 ## Appendix: 中文快速指引
 
@@ -140,4 +150,5 @@ Configure in GitHub → **Settings** → **Branches** → rule for `main`:
 3. **PR 目标分支**：`main`；使用仓库 PR 模板填写说明。
 4. **测试约定**：不要直接调用 coordinator 内部方法；需要加载集成时使用 `enable_custom_integrations` fixture。
 5. **依赖升级**：仅 GitHub Actions 由 Dependabot 自动提 PR；Python 依赖手动升级。升 `pyimouapi` 须同时改 `pyproject.toml`、`manifest.json` 并执行 `uv lock`。
-6. **更多细节**：见上文英文章节。
+6. **CI 触发**：fork PR 自动跑 CI，无需 maintainer 点 Approve and run；Draft PR 需 Ready for review 后触发。
+7. **更多细节**：见上文英文章节。


### PR DESCRIPTION
## Summary

- Add `ready_for_review` (and explicit PR types) to `ci-lint.yml` and `ci-test.yml` so Draft → Ready triggers CI
- Document fork PR CI behavior and Actions settings in `CONTRIBUTING.md`
- Add PR template checklist item for Actions status

## GitHub Settings (already applied via API)

Repo **Fork pull request workflows** approval policy set to `first_time_contributors_new_to_github` (most permissive tier for public repos).

> Public repositories cannot disable fork workflow approval entirely via API. After a contributor’s first approved workflow run, subsequent PRs typically auto-run CI without maintainer action.

## Test plan

- [ ] Merge this PR; open a fork PR and confirm Checks start without Approve and run (for returning contributors)
- [ ] Open Draft PR → Ready for review → confirm Lint/Test workflows trigger