### PR TITLE
Fix/webhook alarm classification 66

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,12 @@ labels: bug
 
 ## What happened?
 
+
 ## Steps to reproduce
 
+
 ## Expected behavior
+
 
 ## Environment
 
@@ -21,6 +24,34 @@ labels: bug
 
 ## Logs
 
+Please enable **debug** logging, reproduce the issue once, then paste the relevant log lines as **text** (not only screenshots).
+
+### Enable debug logging
+
+**Option A — temporary (UI)**  
+1. **Settings → System → Logs**  
+2. Three-dot menu (⋮) → set log level / enable debug  
+3. Set these to **debug**:
+   - `custom_components.imou_life`
+   - `pyimouapi`
+
+**Option B — persistent (`configuration.yaml`)**  
+Then restart Home Assistant:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.imou_life: debug
+    pyimouapi: debug
+```
+
+### What to paste
+
+Search logs for `pyimouapi` / `imou_life` (and for setup failures: `listDeviceDetails`). Prefer lines like `url: ... request body: ... response: ...` that show the API `code` / `msg`.
+
+**Redact** `accessToken` / `token` and any secrets before posting. AppId, API host, and result `code`/`msg` can stay visible.
+
 ```text
-Paste relevant logs here (debug level recommended)
+Paste relevant debug logs here
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [1.3.1]
+### Fixed
+- Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
+
 ## [1.3.0]
 ### Added
 - Reauth flow when App Secret expires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 ## [1.3.1]
+### Changed
+- Event push always syncs to the Imou app (`basePush=1`); removed the Base push option from Configure
+
 ### Fixed
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [1.3.1]
 ### Changed
 - Event push always syncs to the Imou app (`basePush=1`); removed the Base push option from Configure
+- Webhook `iotEvent`: promote `content.event` to `msg_type`; expose `product_id` (`pid`) and `outputData`; treat `iotEvent` / `sirenOn` / `sirenOff` as alarms
 
 ### Fixed
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Devices under your Imou account should appear in Home Assistant. Use **Configure
 
 - **Invalid AppId / AppSecret** — Home Assistant opens a **re-authentication** flow; enter a new App Secret under **Settings → Devices & services → Imou Life** (notification or three-dot menu → **Re-authenticate**).
 - **Event push not working** — Check **Settings → System → Network → Home Assistant URL** (external URL required), or set a manual callback URL in **Configure**. Review repair issues under **Settings → System → Repairs**.
+  - Automations can listen to `imou_life_event` (all accepted pushes) and `imou_life_alarm` (security alarms only). Privacy-mask messages (`openCamera` / `closeCamera`) fire only `imou_life_event`.
+  - If you receive `abAlarmSound` or `closeCamera`, the callback/webhook path is working.
+  - If `videoMotion` / `human` / `mobileDetect` never appear: confirm motion/human detection is enabled on the device; download **Diagnostics** and check `event_push.recent_msg_type_counts`. Missing keys mean the cloud/device did not push those types (not an HA misclassification).
+  - Confirm event push is enabled in **Configure** and push types include **alarm**.
 - **Automations after upgrade** — v1.3.0 removes custom `imou_life.turn_on` / `turn_off` / `select` services; use standard `switch.turn_on`, `select.select_option`, and `button.press`.
 - **Diagnostics** — Download redacted diagnostics from the integration's **Download diagnostics** (three-dot menu on the config entry).
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Devices under your Imou account should appear in Home Assistant. Use **Configure
   - Optional webhook callback for real-time messages from Imou cloud (requires public HA URL or manual callback URL)
   - Home Assistant events: `imou_life_event` (all accepted pushes), `imou_life_alarm` (alarm-type only)
   - Optional notify services for alarm messages
-  - Choose push message types; sync to Imou mobile app or HA-only
+  - Choose push message types; messages are also synced to the Imou mobile app
 * **Camera Function Management**
   - Information and status display (device name, online status, storage status, battery level, etc.)
   - Live video preview

--- a/custom_components/imou_life/config_flow.py
+++ b/custom_components/imou_life/config_flow.py
@@ -33,14 +33,12 @@ from .const import (
     CONF_HTTP,
     CONF_HTTPS,
     CONF_SD,
-    DEFAULT_BASE_PUSH,
     DEFAULT_EVENT_PUSH_TYPES,
     DOMAIN,
     EVENT_PUSH_TYPE_OPTIONS,
     PARAM_API_URL,
     PARAM_APP_ID,
     PARAM_APP_SECRET,
-    PARAM_BASE_PUSH,
     PARAM_DOWNLOAD_SNAP_WAIT_TIME,
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
@@ -333,14 +331,6 @@ class ImouOptionsFlow(OptionsFlow):
                                 options=list(EVENT_PUSH_TYPE_OPTIONS),
                                 multiple=True,
                                 translation_key="event_push_type",
-                            )
-                        ),
-                        vol.Required(
-                            PARAM_BASE_PUSH, default=DEFAULT_BASE_PUSH
-                        ): SelectSelector(
-                            SelectSelectorConfig(
-                                options=["1", "2"],
-                                translation_key="base_push",
                             )
                         ),
                         # --- Notification settings ---

--- a/custom_components/imou_life/const.py
+++ b/custom_components/imou_life/const.py
@@ -41,8 +41,9 @@ PARAM_WEBHOOK_URL = "webhook_url"
 PARAM_SELECTED_DEVICES = "selected_devices"
 PARAM_ENABLE_EVENT_PUSH = "enable_event_push"
 PARAM_EVENT_PUSH_TYPES = "event_push_types"
-PARAM_BASE_PUSH = "base_push"
 PARAM_NOTIFY_SERVICES = "notify_services"
+# Always sync pushes to the Imou app as well as HA (setMessageCallback basePush).
+BASE_PUSH_ALWAYS = "1"
 PARAM_MOTION_DETECT = "motion_detect"
 PARAM_STATUS = "status"
 PARAM_STORAGE_USED = "storage_used"
@@ -137,7 +138,6 @@ def callback_flags_to_event_push_types(flags: list[str]) -> list[str]:
 
 EVENT_IMOU_EVENT = f"{DOMAIN}_event"
 EVENT_IMOU_ALARM = f"{DOMAIN}_alarm"
-DEFAULT_BASE_PUSH = "2"
 
 # service
 SERVICE_CONTROL_MOVE_PTZ = "control_move_ptz"

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -9,10 +9,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import (
-    DEFAULT_BASE_PUSH,
+    BASE_PUSH_ALWAYS,
     PARAM_API_URL,
     PARAM_APP_ID,
-    PARAM_BASE_PUSH,
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
     PARAM_SELECTED_DEVICES,
@@ -48,7 +47,7 @@ async def async_get_config_entry_diagnostics(
         "enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
         "webhook_url_configured": bool(webhook_url),
         "event_push_types": list(entry.options.get(PARAM_EVENT_PUSH_TYPES, [])),
-        "base_push": entry.options.get(PARAM_BASE_PUSH, DEFAULT_BASE_PUSH),
+        "base_push": BASE_PUSH_ALWAYS,
         "selected_devices_count": len(selected),
         "recent_msg_type_counts": (
             dict(runtime.push_msg_type_counts) if runtime is not None else {}

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -53,9 +53,7 @@ async def async_get_config_entry_diagnostics(
         "recent_msg_type_counts": (
             dict(runtime.push_msg_type_counts) if runtime is not None else {}
         ),
-        "last_msg_type": (
-            runtime.push_last_msg_type if runtime is not None else None
-        ),
+        "last_msg_type": (runtime.push_last_msg_type if runtime is not None else None),
         "last_received_at": last_received,
     }
 

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -9,9 +9,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import (
+    DEFAULT_BASE_PUSH,
     PARAM_API_URL,
     PARAM_APP_ID,
+    PARAM_BASE_PUSH,
     PARAM_ENABLE_EVENT_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
     PARAM_SELECTED_DEVICES,
     PARAM_WEBHOOK_ID,
     PARAM_WEBHOOK_URL,
@@ -29,10 +32,32 @@ async def async_get_config_entry_diagnostics(
         PARAM_SELECTED_DEVICES, []
     )
 
-    coordinator = entry.runtime_data.coordinator if entry.runtime_data else None
+    runtime = entry.runtime_data
+    coordinator = runtime.coordinator if runtime is not None else None
     last_update_success = (
         coordinator.last_update_success if coordinator is not None else None
     )
+
+    last_received = (
+        runtime.push_last_received_at.isoformat()
+        if runtime is not None and runtime.push_last_received_at is not None
+        else None
+    )
+
+    event_push = {
+        "enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
+        "webhook_url_configured": bool(webhook_url),
+        "event_push_types": list(entry.options.get(PARAM_EVENT_PUSH_TYPES, [])),
+        "base_push": entry.options.get(PARAM_BASE_PUSH, DEFAULT_BASE_PUSH),
+        "selected_devices_count": len(selected),
+        "recent_msg_type_counts": (
+            dict(runtime.push_msg_type_counts) if runtime is not None else {}
+        ),
+        "last_msg_type": (
+            runtime.push_last_msg_type if runtime is not None else None
+        ),
+        "last_received_at": last_received,
+    }
 
     return {
         "app_id": f"{app_id[:4]}…" if len(app_id) > 4 else app_id,
@@ -43,4 +68,5 @@ async def async_get_config_entry_diagnostics(
         "webhook_url_configured": bool(webhook_url),
         "last_update_success": last_update_success,
         "pyimouapi_version": version("pyimouapi"),
+        "event_push": event_push,
     }

--- a/custom_components/imou_life/event_push.py
+++ b/custom_components/imou_life/event_push.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from pyimouapi.openapi import ImouOpenApiClient
 
 from .const import (
-    PARAM_BASE_PUSH,
+    BASE_PUSH_ALWAYS,
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
     PARAM_NOTIFY_SERVICES,
@@ -94,7 +94,6 @@ async def _async_set_message_callback(
     callback_flags = event_push_types_to_callback_flags(
         entry.options.get(PARAM_EVENT_PUSH_TYPES, [])
     )
-    base_push = entry.options.get(PARAM_BASE_PUSH, "2")
     if status == "on":
         if not callback_url:
             _LOGGER.error(
@@ -109,7 +108,7 @@ async def _async_set_message_callback(
                 status="on",
                 callback_url=callback_url,
                 callback_flag=callback_flags if callback_flags else None,
-                base_push=base_push,
+                base_push=BASE_PUSH_ALWAYS,
             )
             _LOGGER.info(
                 "Imou message callback set to %s (url=%s)",
@@ -124,7 +123,7 @@ async def _async_set_message_callback(
         try:
             await imou_client.async_set_message_callback(
                 status="off",
-                base_push=base_push,
+                base_push=BASE_PUSH_ALWAYS,
             )
             _LOGGER.info(
                 "Imou message callback set to %s (url=%s)",

--- a/custom_components/imou_life/event_push.py
+++ b/custom_components/imou_life/event_push.py
@@ -25,7 +25,11 @@ from .repairs import (
     async_delete_event_push_issues,
 )
 from .runtime_data import ImouRuntimeData
-from .webhook import async_register_imou_webhook, async_unregister_imou_webhook
+from .webhook import (
+    async_preload_webhook_strings,
+    async_register_imou_webhook,
+    async_unregister_imou_webhook,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +57,7 @@ async def async_setup_event_push(
         return webhook_id, ""
 
     generated_url = async_register_imou_webhook(hass, webhook_id)
+    await async_preload_webhook_strings(hass)
 
     if entry.options.get(PARAM_ENABLE_EVENT_PUSH):
         await _async_set_message_callback(hass, entry, imou_client, "on", generated_url)

--- a/custom_components/imou_life/runtime_data.py
+++ b/custom_components/imou_life/runtime_data.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .coordinator import ImouDataUpdateCoordinator
+
+_MAX_PUSH_MSG_TYPE_KEYS = 50
 
 
 @dataclass
@@ -17,3 +20,21 @@ class ImouRuntimeData:
     push_enabled: bool = False
     selected_devices: list[str] = field(default_factory=list)
     notify_services: list[str] = field(default_factory=list)
+    push_msg_type_counts: dict[str, int] = field(default_factory=dict)
+    push_last_msg_type: str | None = None
+    push_last_received_at: datetime | None = None
+
+    def record_push_msg(self, msg_type: str | None) -> None:
+        """Record an accepted push for diagnostics (in-memory only)."""
+        display = msg_type if msg_type is not None else "_unknown"
+        count_key = display
+        if (
+            count_key not in self.push_msg_type_counts
+            and len(self.push_msg_type_counts) >= _MAX_PUSH_MSG_TYPE_KEYS
+        ):
+            count_key = "_other"
+        self.push_msg_type_counts[count_key] = (
+            self.push_msg_type_counts.get(count_key, 0) + 1
+        )
+        self.push_last_msg_type = display
+        self.push_last_received_at = datetime.now(UTC)

--- a/custom_components/imou_life/strings.json
+++ b/custom_components/imou_life/strings.json
@@ -60,7 +60,6 @@
           "enable_event_push": "Enable event push",
           "webhook_url": "Callback URL",
           "event_push_types": "Event push types",
-          "base_push": "Sync to Imou mobile app",
           "notify_services": "Alarm notification services"
         },
         "data_description": {
@@ -69,10 +68,9 @@
           "live_resolution": "Camera live stream resolution. HD = high definition, SD = standard.",
           "live_protocol": "Video stream protocol. Usually https is fine.",
           "rotation_duration": "How long a single PTZ button press moves. Default 500ms.",
-          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS).",
+          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS). Messages are also synced to the Imou app.",
           "webhook_url": "The URL where Imou cloud sends alarm messages. Leave empty to auto-generate (requires HA external URL configured). To set manually, enter full URL like: https://yourdomain:8123/api/webhook/xxxxx",
           "event_push_types": "Select which message types to receive. alarm = device alarms (smoke/gas/human/motion etc.), deviceStatus = online/offline, iot = IoT device messages, numberstat = people counting, faceAnalysis = face detection.",
-          "base_push": "Whether to also push messages to the Imou APP. 'Push' = Imou APP also receives, 'No push' = HA only.",
           "notify_services": "Where to send alarm notifications. Enter HA action names, separate with commas.\nExample: qiyewechat.send → WeChat Work\nExample: notify.mobile_app_xxx → HA APP push\nBoth: qiyewechat.send,notify.mobile_app_xxx\nLeave empty to skip (alarm events still fire for automations)."
         }
       },
@@ -99,12 +97,6 @@
         "iot": "IoT device messages",
         "numberstat": "People counting",
         "face_analysis": "Face analysis"
-      }
-    },
-    "base_push": {
-      "options": {
-        "1": "Push to Imou app",
-        "2": "Home Assistant only"
       }
     },
     "device_status": {

--- a/custom_components/imou_life/translations/en.json
+++ b/custom_components/imou_life/translations/en.json
@@ -60,7 +60,6 @@
           "enable_event_push": "Enable event push",
           "webhook_url": "Callback URL",
           "event_push_types": "Event push types",
-          "base_push": "Sync to Imou mobile app",
           "notify_services": "Alarm notification services"
         },
         "data_description": {
@@ -69,10 +68,9 @@
           "live_resolution": "Camera live stream resolution. HD = high definition, SD = standard.",
           "live_protocol": "Video stream protocol. Usually https is fine.",
           "rotation_duration": "How long a single PTZ button press moves. Default 500ms.",
-          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS).",
+          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS). Messages are also synced to the Imou app.",
           "webhook_url": "The URL where Imou cloud sends alarm messages. Leave empty to auto-generate (requires HA external URL configured). To set manually, enter full URL like: https://yourdomain:8123/api/webhook/xxxxx",
           "event_push_types": "Select which message types to receive. alarm = device alarms (smoke/gas/human/motion etc.), deviceStatus = online/offline, iot = IoT device messages, numberstat = people counting, faceAnalysis = face detection.",
-          "base_push": "Whether to also push messages to the Imou APP. 'Push' = Imou APP also receives, 'No push' = HA only.",
           "notify_services": "Where to send alarm notifications. Enter HA action names, separate with commas.\nExample: qiyewechat.send → WeChat Work\nExample: notify.mobile_app_xxx → HA APP push\nBoth: qiyewechat.send,notify.mobile_app_xxx\nLeave empty to skip (alarm events still fire for automations)."
         }
       },
@@ -99,12 +97,6 @@
         "iot": "IoT device messages",
         "numberstat": "People counting",
         "face_analysis": "Face analysis"
-      }
-    },
-    "base_push": {
-      "options": {
-        "1": "Push to Imou app",
-        "2": "Home Assistant only"
       }
     },
     "device_status": {

--- a/custom_components/imou_life/translations/zh-Hans.json
+++ b/custom_components/imou_life/translations/zh-Hans.json
@@ -60,7 +60,6 @@
           "enable_event_push": "启用消息推送",
           "webhook_url": "消息回调地址",
           "event_push_types": "推送消息类型",
-          "base_push": "乐橙APP消息同步",
           "notify_services": "报警通知服务"
         },
         "data_description": {
@@ -69,10 +68,9 @@
           "live_resolution": "摄像头直播的分辨率，HD=高清，SD=标清",
           "live_protocol": "视频流协议，一般用https即可",
           "rotation_duration": "按一次云台方向按钮转多久，默认500毫秒",
-          "enable_event_push": "打开后，乐橙云会把设备报警消息实时推送到你的HA。需要HA有公网可访问的地址（域名/DDNS均可）",
+          "enable_event_push": "打开后，乐橙云会把设备报警消息实时推送到你的HA，并同步推送到乐橙APP。需要HA有公网可访问的地址（域名/DDNS均可）",
           "webhook_url": "乐橙云把报警消息推到哪个地址。留空会自动生成（前提是HA已配置外部URL）。如果自动生成不对，手动填完整URL，格式如：https://你的域名:8123/api/webhook/xxxxx",
           "event_push_types": "选择要接收哪些类型的消息。alarm=设备报警（烟感/燃气/人形/动检等），deviceStatus=设备上下线，iot=物联网设备消息，numberstat=客流统计，faceAnalysis=人脸智能分析",
-          "base_push": "是否同时把消息推送给乐橙APP。选\"推送\"=乐橙APP也会收到，选\"不推送\"=只推给HA",
           "notify_services": "收到报警后自动发通知到哪里。填HA的动作名称，多个用英文逗号分隔。\n\n查找方法：HA → 开发者工具 → 动作 → 搜索你要用的通知服务\n\n例如：qiyewechat.send  →  企业微信通知\n例如：notify.mobile_app_xxx  →  HA APP弹窗通知\n同时推两个：qiyewechat.send,notify.mobile_app_xxx\n\n留空则不自动发通知（但报警事件仍会触发，可在自动化中使用）"
         }
       },
@@ -99,12 +97,6 @@
         "iot": "物联网设备消息",
         "numberstat": "客流统计",
         "face_analysis": "人脸智能分析"
-      }
-    },
-    "base_push": {
-      "options": {
-        "1": "推送",
-        "2": "不推送"
       }
     },
     "device_status": {

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -261,6 +261,8 @@ async def async_handle_imou_webhook(
         )
         return web.Response(status=200, text="ok")
 
+    runtime.record_push_msg(msg_type)
+
     # Always fire the generic event
     hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)
 

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -20,19 +20,58 @@ _LOGGER = logging.getLogger(__name__)
 
 _WEBHOOK_STRINGS_DIR = Path(__file__).parent / "webhook_strings"
 
-# Message types that are NOT alarm events (status / iot / stats)
-_NON_ALARM_TYPES = frozenset(
+# Status / ops types that must NOT fire imou_life_alarm or notify.
+# Official Imou "Device alarm" list also includes privacy-mask and lifecycle
+# types; we subtract those here. See:
+# https://open.imoulife.com/book/en/push/alarm.html
+_NON_ALARM_MSG_TYPES = frozenset(
     {
+        # deviceStatus
         "online",
         "offline",
         "close",
         "changeDevName",
+        # iot / stats
         "iotEvent",
         "iotProperty",
         "iotAction",
         "numberstat",
+        # privacy mask (#66)
+        "openCamera",
+        "closeCamera",
+        # light / siren state
+        "whiteLightOn",
+        "whiteLightOff",
+        "sirenOn",
+        "sirenOff",
+        # sleep
+        "sleep",
+        # bind / share / auth / transfer
+        "bindDevice",
+        "unbindDevice",
+        "deviceShare",
+        "deviceShareCancel",
+        "deviceAuthorize",
+        "deviceAuthorizationChanged",
+        "transferDeviceFrom",
+        "transferDeviceTo",
+        "deviceDeletedSharedCancel",
+        # upgrade / storage ops
+        "UpgradeSuccess",
+        "upgradeFail",
+        "apUpgradeSuccess",
+        "apUpgradeFail",
+        "storageRecoverOk",
+        "storageRecoverFail",
+        "storageEmpty",
+        "storageAbnormal",
     }
 )
+
+
+def _is_alarm_msg_type(msg_type: str | None) -> bool:
+    """Return True if this push should fire imou_life_alarm / notify."""
+    return msg_type is not None and msg_type not in _NON_ALARM_MSG_TYPES
 
 
 def _webhook_strings_filename(language: str) -> str:
@@ -225,8 +264,8 @@ async def async_handle_imou_webhook(
     # Always fire the generic event
     hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)
 
-    # Fire alarm-specific event + send notifications for non-status messages
-    is_alarm = msg_type not in _NON_ALARM_TYPES
+    # Fire alarm-specific event + send notifications for security alarms
+    is_alarm = _is_alarm_msg_type(msg_type)
     if is_alarm:
         hass.bus.async_fire(EVENT_IMOU_ALARM, event_data)
 

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -79,15 +79,27 @@ def _webhook_strings_filename(language: str) -> str:
 
 @lru_cache(maxsize=4)
 def _load_webhook_strings_file(filename: str) -> dict[str, Any]:
+    """Load a webhook strings JSON file (blocking; call via executor)."""
     path = _WEBHOOK_STRINGS_DIR / filename
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _get_webhook_strings(
+_WEBHOOK_STRING_FILES = ("en.json", "zh-Hans.json")
+
+
+async def async_preload_webhook_strings(hass: HomeAssistant) -> None:
+    """Warm webhook string cache off the event loop."""
+    for filename in _WEBHOOK_STRING_FILES:
+        await hass.async_add_executor_job(_load_webhook_strings_file, filename)
+
+
+async def _async_get_webhook_strings(
+    hass: HomeAssistant,
     language: str,
 ) -> tuple[dict[str, str], dict[str, str]]:
     """Load webhook notification templates and alarm type labels."""
-    data = _load_webhook_strings_file(_webhook_strings_filename(language))
+    filename = _webhook_strings_filename(language)
+    data = await hass.async_add_executor_job(_load_webhook_strings_file, filename)
     notification = data.get("notification", {})
     alarm_types = data.get("alarm_types", {})
     return notification, alarm_types
@@ -144,7 +156,7 @@ async def _async_build_notification_message(
     hass: HomeAssistant, event_data: dict[str, Any]
 ) -> tuple[str, str]:
     """Build a notification title and message from an event payload."""
-    notif, alarm_types = _get_webhook_strings(hass.config.language)
+    notif, alarm_types = await _async_get_webhook_strings(hass, hass.config.language)
 
     msg_type = event_data.get("msg_type")
     unknown_device = notif.get("unknown_device", "Unknown device")

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -31,19 +31,16 @@ _NON_ALARM_MSG_TYPES = frozenset(
         "offline",
         "close",
         "changeDevName",
-        # iot / stats
-        "iotEvent",
+        # iot property/action & stats (iotEvent is an alarm)
         "iotProperty",
         "iotAction",
         "numberstat",
         # privacy mask (#66)
         "openCamera",
         "closeCamera",
-        # light / siren state
+        # light state (sirenOn/sirenOff are alarms)
         "whiteLightOn",
         "whiteLightOff",
-        "sirenOn",
-        "sirenOff",
         # sleep
         "sleep",
         # bind / share / auth / transfer
@@ -112,6 +109,18 @@ def _normalize_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
         or payload.get("channels")
     )
     msg_type = payload.get("msgType")
+    content = payload.get("content")
+    output_data = None
+    if isinstance(content, dict):
+        iot_event = content.get("event")
+        if msg_type == "iotEvent" and iot_event is not None and iot_event != "":
+            msg_type = str(iot_event)
+        output_data = content.get("outputData")
+        if channel_id is None:
+            monitor = content.get("monitor")
+            if isinstance(monitor, dict) and "channel" in monitor:
+                channel_id = monitor.get("channel")
+
     raw_time = payload.get("time") or payload.get("localTime") or payload.get("utcTime")
 
     event = {
@@ -119,11 +128,13 @@ def _normalize_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "msg_type_name": msg_type,
         "device_id": device_id,
         "channel_id": channel_id,
+        "product_id": payload.get("pid"),
         "time": raw_time,
         "name": payload.get("cname") or payload.get("dname"),
         "alarm_id": payload.get("id") or payload.get("alarmId"),
         "token": payload.get("token"),
         "desc": payload.get("desc"),
+        "outputData": output_data,
         "raw": payload,
     }
     return event

--- a/docs/superpowers/plans/2026-07-21-imou-webhook-alarm-classification.md
+++ b/docs/superpowers/plans/2026-07-21-imou-webhook-alarm-classification.md
@@ -1,0 +1,776 @@
+# Webhook 报警分类与推送可观测性 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 #66：将 `openCamera`/`closeCamera` 等非安防推送排除出 `imou_life_alarm`，并用 runtime 计数 + diagnostics 支撑动检/人形漏推排查。
+
+**Architecture:** 混合判定（默认报警 − `NON_ALARM_MSG_TYPES` 黑名单）；webhook 在通过过滤后更新 `ImouRuntimeData` 内存计数；diagnostics 输出本地 push 配置与近期 `msgType` 统计。不轮询、不调用 `getMessageCallback`。
+
+**Tech Stack:** Home Assistant custom integration (`imou_life`), pytest, pytest-homeassistant-custom-component, ruff, uv
+
+**Spec:** `docs/superpowers/specs/2026-07-21-imou-webhook-alarm-classification-design.md`
+
+## Global Constraints
+
+- 仓库：`Imou-Home-Assistant` only（不改 pyimouapi / HA core）
+- 事件名与 payload 字段不变：`imou_life_event` / `imou_life_alarm`
+- Webhook 始终 HTTP 200
+- 计数仅内存、不持久化、不做实体
+- 每个 Task 结束后：相关 pytest 通过；Task 末 `git commit`（勿提交无关 sensor/1.3.1 脏文件）
+- 验证命令：`uv run pytest tests/test_webhook.py tests/test_diagnostics.py -q --timeout=30`；最终 `script/lint-check` + `script/test`
+
+## 文件影响总览
+
+| 文件 | 职责 |
+|------|------|
+| `custom_components/imou_life/webhook.py` | `NON_ALARM_MSG_TYPES`、`_is_alarm_msg_type`、handler 判定与计数调用 |
+| `custom_components/imou_life/runtime_data.py` | push 计数字段 + `record_push_msg` |
+| `custom_components/imou_life/diagnostics.py` | `event_push` 诊断块 |
+| `tests/test_webhook.py` | 分类、notify、计数测试 |
+| `tests/test_diagnostics.py` | diagnostics 字段测试 |
+| `README.md` | Troubleshooting Event push |
+| `CHANGELOG.md` | Fixed 条目（写入当前未发布版本节，现为 `[1.3.1]`） |
+
+---
+
+### Task 1: 报警分类辅助函数（TDD）
+
+**Files:**
+- Modify: `custom_components/imou_life/webhook.py`
+- Test: `tests/test_webhook.py`
+
+**Interfaces:**
+- Produces: `_is_alarm_msg_type(msg_type: str | None) -> bool`
+- Produces: `NON_ALARM_MSG_TYPES: frozenset[str]`（可保持模块级私有名 `_NON_ALARM_MSG_TYPES`，但测试从 `webhook` 导入 `_is_alarm_msg_type`）
+
+- [ ] **Step 1: Write the failing tests**
+
+在 `tests/test_webhook.py` 追加：
+
+```python
+from custom_components.imou_life.webhook import _is_alarm_msg_type
+
+
+@pytest.mark.parametrize(
+    ("msg_type", "expected"),
+    [
+        ("closeCamera", False),
+        ("openCamera", False),
+        ("online", False),
+        ("iotProperty", False),
+        ("whiteLightOn", False),
+        ("bindDevice", False),
+        ("videoMotion", True),
+        ("human", True),
+        ("abAlarmSound", True),
+        ("mobileDetect", True),
+        ("alarmLocal", True),
+        ("totallyUnknownType", True),
+        (None, False),
+    ],
+)
+def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
+    """Hybrid classification: denylist non-alarms; unknown types are alarms."""
+    assert _is_alarm_msg_type(msg_type) is expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/open/projects/Imou-Home-Assistant
+uv run pytest tests/test_webhook.py::test_is_alarm_msg_type -v --timeout=30
+```
+
+Expected: `ImportError` 或 `AttributeError`（`_is_alarm_msg_type` 不存在）
+
+- [ ] **Step 3: Implement classification in `webhook.py`**
+
+替换原 `_NON_ALARM_TYPES`（约 L23–35）为：
+
+```python
+# Status / ops types that must NOT fire imou_life_alarm or notify.
+# Official Imou "Device alarm" list also includes privacy-mask and lifecycle
+# types; we subtract those here. See:
+# https://open.imoulife.com/book/en/push/alarm.html
+_NON_ALARM_MSG_TYPES = frozenset(
+    {
+        # deviceStatus
+        "online",
+        "offline",
+        "close",
+        "changeDevName",
+        # iot / stats
+        "iotEvent",
+        "iotProperty",
+        "iotAction",
+        "numberstat",
+        # privacy mask (#66)
+        "openCamera",
+        "closeCamera",
+        # light / siren state
+        "whiteLightOn",
+        "whiteLightOff",
+        "sirenOn",
+        "sirenOff",
+        # sleep
+        "sleep",
+        # bind / share / auth / transfer
+        "bindDevice",
+        "unbindDevice",
+        "deviceShare",
+        "deviceShareCancel",
+        "deviceAuthorize",
+        "deviceAuthorizationChanged",
+        "transferDeviceFrom",
+        "transferDeviceTo",
+        "deviceDeletedSharedCancel",
+        # upgrade / storage ops
+        "UpgradeSuccess",
+        "upgradeFail",
+        "apUpgradeSuccess",
+        "apUpgradeFail",
+        "storageRecoverOk",
+        "storageRecoverFail",
+        "storageEmpty",
+        "storageAbnormal",
+    }
+)
+
+
+def _is_alarm_msg_type(msg_type: str | None) -> bool:
+    """Return True if this push should fire imou_life_alarm / notify."""
+    return msg_type is not None and msg_type not in _NON_ALARM_MSG_TYPES
+```
+
+将 handler 中：
+
+```python
+is_alarm = msg_type not in _NON_ALARM_TYPES
+```
+
+改为：
+
+```python
+is_alarm = _is_alarm_msg_type(msg_type)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/test_webhook.py::test_is_alarm_msg_type tests/test_webhook.py::test_webhook_iot_property_is_not_alarm -v --timeout=30
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/imou_life/webhook.py tests/test_webhook.py
+git commit -m "$(cat <<'EOF'
+fix: classify privacy-mask pushes as non-alarm events
+
+Exclude openCamera/closeCamera and other status/ops msgTypes from
+imou_life_alarm so automations and notify are not misfired (#66).
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Webhook 集成行为（closeCamera / 真报警 / notify）
+
+**Files:**
+- Modify: `tests/test_webhook.py`
+- Modify: `custom_components/imou_life/webhook.py`（仅当 Task 1 未改全 handler 时）
+
+**Interfaces:**
+- Consumes: `_is_alarm_msg_type`, `async_handle_imou_webhook`, `setup_imou_runtime`
+
+- [ ] **Step 1: Write the failing tests**
+
+在 `tests/test_webhook.py` 追加：
+
+```python
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["closeCamera", "openCamera"])
+async def test_webhook_privacy_mask_is_not_alarm(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Privacy mask open/close fires generic event only."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["device_1"],
+        notify_services=["notify.test"],
+    )
+    hass.services.async_register("notify", "test", lambda call: None)
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": msg_type,
+                "did": "device_1",
+                "cid": 0,
+                "dname": "Cam",
+                "time": 1783528060,
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert generic_events[0].data["msg_type"] == msg_type
+    assert alarm_events == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["videoMotion", "human", "abAlarmSound"])
+async def test_webhook_security_alarms_fire_alarm_event(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Security alarm msgTypes fire both generic and alarm events."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": msg_type, "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 1
+    assert alarm_events[0].data["msg_type"] == msg_type
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_missing_msg_type_is_not_alarm(
+    hass: HomeAssistant,
+) -> None:
+    """Payload without msgType still fires generic event, not alarm."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert alarm_events == []
+```
+
+若 `hass.services.async_register("notify", "test", ...)` 在当前 HA 测试环境签名不兼容，改为只断言 `alarm_events == []`（notify 仅在 `is_alarm` 时调用，无 alarm 即无 notify）。优先保留无 alarm 断言即可满足 #66。
+
+- [ ] **Step 2: Run tests**
+
+```bash
+uv run pytest tests/test_webhook.py::test_webhook_privacy_mask_is_not_alarm \
+  tests/test_webhook.py::test_webhook_security_alarms_fire_alarm_event \
+  tests/test_webhook.py::test_webhook_missing_msg_type_is_not_alarm -v --timeout=30
+```
+
+Expected: PASS（Task 1 已改 handler）；若 FAIL，检查 handler 是否仍用旧 `_NON_ALARM_TYPES` 名称。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_webhook.py
+git commit -m "$(cat <<'EOF'
+test: cover webhook alarm vs privacy-mask event split
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Runtime 推送计数
+
+**Files:**
+- Modify: `custom_components/imou_life/runtime_data.py`
+- Modify: `custom_components/imou_life/webhook.py`
+- Test: `tests/test_webhook.py`
+
+**Interfaces:**
+- Produces on `ImouRuntimeData`:
+  - `push_msg_type_counts: dict[str, int]`
+  - `push_last_msg_type: str | None`
+  - `push_last_received_at: datetime | None`
+  - `record_push_msg(self, msg_type: str | None) -> None`
+- Consumes in webhook: after device filter passes, before/after `async_fire(EVENT_IMOU_EVENT)` 调用 `runtime.record_push_msg(msg_type)`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_records_msg_type_counts(hass: HomeAssistant) -> None:
+    """Accepted pushes increment runtime msgType counters."""
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "abAlarmSound", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts["closeCamera"] == 2
+    assert runtime.push_msg_type_counts["abAlarmSound"] == 1
+    assert runtime.push_last_msg_type == "abAlarmSound"
+    assert runtime.push_last_received_at is not None
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_filtered_device_does_not_count(
+    hass: HomeAssistant,
+) -> None:
+    """Unselected devices do not update push counters."""
+    runtime = setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["selected_device"],
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "alarmLocal", "deviceId": "other_device"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts == {}
+    assert runtime.push_last_msg_type is None
+```
+
+另加纯单元测试（可不依赖 HA fixture）：
+
+```python
+from datetime import UTC, datetime
+
+from custom_components.imou_life.runtime_data import ImouRuntimeData
+
+
+def test_record_push_msg_caps_distinct_keys() -> None:
+    """More than 50 distinct msgTypes fold into _other."""
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    for i in range(50):
+        runtime.record_push_msg(f"type_{i}")
+    assert len(runtime.push_msg_type_counts) == 50
+    runtime.record_push_msg("type_extra")
+    assert runtime.push_msg_type_counts["_other"] == 1
+    assert "type_extra" not in runtime.push_msg_type_counts
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/test_webhook.py::test_webhook_records_msg_type_counts \
+  tests/test_webhook.py::test_webhook_filtered_device_does_not_count \
+  tests/test_webhook.py::test_record_push_msg_caps_distinct_keys -v --timeout=30
+```
+
+Expected: FAIL（缺字段 / `record_push_msg`）
+
+- [ ] **Step 3: Implement `runtime_data.py`**
+
+```python
+"""Runtime data stored on Imou config entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .coordinator import ImouDataUpdateCoordinator
+
+_MAX_PUSH_MSG_TYPE_KEYS = 50
+
+
+@dataclass
+class ImouRuntimeData:
+    """Data attached to a config entry at runtime."""
+
+    coordinator: ImouDataUpdateCoordinator
+    push_enabled: bool = False
+    selected_devices: list[str] = field(default_factory=list)
+    notify_services: list[str] = field(default_factory=list)
+    push_msg_type_counts: dict[str, int] = field(default_factory=dict)
+    push_last_msg_type: str | None = None
+    push_last_received_at: datetime | None = None
+
+    def record_push_msg(self, msg_type: str | None) -> None:
+        """Record an accepted push for diagnostics (in-memory only)."""
+        key = msg_type if msg_type is not None else "_unknown"
+        if (
+            key not in self.push_msg_type_counts
+            and len(self.push_msg_type_counts) >= _MAX_PUSH_MSG_TYPE_KEYS
+        ):
+            key = "_other"
+        self.push_msg_type_counts[key] = self.push_msg_type_counts.get(key, 0) + 1
+        self.push_last_msg_type = msg_type if msg_type is not None else "_unknown"
+        self.push_last_received_at = datetime.now(UTC)
+```
+
+注意：封顶后 `push_last_msg_type` 仍应反映真实类型还是 `_other`？按可观测性意图，**last 用真实 `msg_type`（或 `_unknown`）**，计数键在封顶时用 `_other`：
+
+```python
+    def record_push_msg(self, msg_type: str | None) -> None:
+        """Record an accepted push for diagnostics (in-memory only)."""
+        display = msg_type if msg_type is not None else "_unknown"
+        count_key = display
+        if (
+            count_key not in self.push_msg_type_counts
+            and len(self.push_msg_type_counts) >= _MAX_PUSH_MSG_TYPE_KEYS
+        ):
+            count_key = "_other"
+        self.push_msg_type_counts[count_key] = (
+            self.push_msg_type_counts.get(count_key, 0) + 1
+        )
+        self.push_last_msg_type = display
+        self.push_last_received_at = datetime.now(UTC)
+```
+
+同步调整 `test_record_push_msg_caps_distinct_keys`：`push_last_msg_type == "type_extra"` 且 `counts["_other"] == 1`。
+
+- [ ] **Step 4: Wire webhook**
+
+在 `async_handle_imou_webhook` 中，设备过滤通过之后、`hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)` 之前插入：
+
+```python
+    runtime.record_push_msg(msg_type)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/test_webhook.py -q --timeout=30
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/imou_life/runtime_data.py \
+  custom_components/imou_life/webhook.py tests/test_webhook.py
+git commit -m "$(cat <<'EOF'
+feat: track webhook msgType counts on runtime data
+
+Expose in-memory counters for diagnostics so missing motion/human
+pushes can be distinguished from misclassification (#66).
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Diagnostics `event_push` 块
+
+**Files:**
+- Modify: `custom_components/imou_life/diagnostics.py`
+- Modify: `tests/test_diagnostics.py`
+
+**Interfaces:**
+- Consumes: `ImouRuntimeData.push_*`、`PARAM_EVENT_PUSH_TYPES`、`PARAM_BASE_PUSH`、`DEFAULT_BASE_PUSH`
+- Produces diagnostics key `event_push: dict[str, Any]`
+
+- [ ] **Step 1: Write the failing test**
+
+更新/扩展 `tests/test_diagnostics.py`：
+
+```python
+"""Tests for Imou Life diagnostics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from custom_components.imou_life.const import (
+    DOMAIN,
+    PARAM_BASE_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
+    PARAM_WEBHOOK_ID,
+)
+from custom_components.imou_life.diagnostics import async_get_config_entry_diagnostics
+from custom_components.imou_life.runtime_data import ImouRuntimeData
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from . import USER_INPUT
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_diagnostics_redacts_secrets(hass) -> None:
+    """Diagnostics must not expose App Secret."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**USER_INPUT, PARAM_WEBHOOK_ID: "abcd1234efgh5678"},
+        options={"enable_event_push": True},
+    )
+    entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    entry.runtime_data = ImouRuntimeData(coordinator=coordinator)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "app_secret" not in result
+    assert result["app_id"] == "test…"
+    assert result["webhook_id"] == "abcd1234…"
+    assert result["event_push_enabled"] is True
+    assert result["last_update_success"] is True
+    assert "pyimouapi_version" in result
+    assert result["event_push"]["enabled"] is True
+    assert result["event_push"]["recent_msg_type_counts"] == {}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_diagnostics_includes_push_msg_counts(hass) -> None:
+    """Diagnostics expose runtime push msgType counters."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**USER_INPUT, PARAM_WEBHOOK_ID: "abcd1234efgh5678"},
+        options={
+            "enable_event_push": True,
+            PARAM_EVENT_PUSH_TYPES: ["alarm", "device_status"],
+            PARAM_BASE_PUSH: "2",
+            "webhook_url": "https://example.com/hook",
+        },
+    )
+    entry.add_to_hass(hass)
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    runtime.record_push_msg("closeCamera")
+    runtime.record_push_msg("abAlarmSound")
+    entry.runtime_data = runtime
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    event_push = result["event_push"]
+
+    assert event_push["enabled"] is True
+    assert event_push["webhook_url_configured"] is True
+    assert event_push["event_push_types"] == ["alarm", "device_status"]
+    assert event_push["base_push"] == "2"
+    assert event_push["recent_msg_type_counts"] == {
+        "closeCamera": 1,
+        "abAlarmSound": 1,
+    }
+    assert event_push["last_msg_type"] == "abAlarmSound"
+    assert event_push["last_received_at"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_diagnostics.py -v --timeout=30
+```
+
+Expected: FAIL（缺 `event_push`）
+
+- [ ] **Step 3: Implement diagnostics**
+
+```python
+"""Diagnostics support for Imou Life."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DEFAULT_BASE_PUSH,
+    PARAM_API_URL,
+    PARAM_APP_ID,
+    PARAM_BASE_PUSH,
+    PARAM_ENABLE_EVENT_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
+    PARAM_SELECTED_DEVICES,
+    PARAM_WEBHOOK_ID,
+    PARAM_WEBHOOK_URL,
+)
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    app_id = entry.data.get(PARAM_APP_ID, "")
+    webhook_id = entry.data.get(PARAM_WEBHOOK_ID, "")
+    webhook_url = entry.options.get(PARAM_WEBHOOK_URL, "")
+    selected = entry.options.get(PARAM_SELECTED_DEVICES) or entry.data.get(
+        PARAM_SELECTED_DEVICES, []
+    )
+
+    runtime = entry.runtime_data
+    coordinator = runtime.coordinator if runtime is not None else None
+    last_update_success = (
+        coordinator.last_update_success if coordinator is not None else None
+    )
+
+    last_received = (
+        runtime.push_last_received_at.isoformat()
+        if runtime is not None and runtime.push_last_received_at is not None
+        else None
+    )
+
+    event_push = {
+        "enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
+        "webhook_url_configured": bool(webhook_url),
+        "event_push_types": list(entry.options.get(PARAM_EVENT_PUSH_TYPES, [])),
+        "base_push": entry.options.get(PARAM_BASE_PUSH, DEFAULT_BASE_PUSH),
+        "selected_devices_count": len(selected),
+        "recent_msg_type_counts": (
+            dict(runtime.push_msg_type_counts) if runtime is not None else {}
+        ),
+        "last_msg_type": (
+            runtime.push_last_msg_type if runtime is not None else None
+        ),
+        "last_received_at": last_received,
+    }
+
+    return {
+        "app_id": f"{app_id[:4]}…" if len(app_id) > 4 else app_id,
+        "api_url": entry.data.get(PARAM_API_URL),
+        "selected_devices_count": len(selected),
+        "event_push_enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
+        "webhook_id": f"{webhook_id[:8]}…" if len(webhook_id) > 8 else webhook_id,
+        "webhook_url_configured": bool(webhook_url),
+        "last_update_success": last_update_success,
+        "pyimouapi_version": version("pyimouapi"),
+        "event_push": event_push,
+    }
+```
+
+保留顶层旧字段（`event_push_enabled` 等）以免破坏已有诊断阅读习惯；新细节放在 `event_push` 下。
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_diagnostics.py tests/test_webhook.py -q --timeout=30
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/imou_life/diagnostics.py tests/test_diagnostics.py
+git commit -m "$(cat <<'EOF'
+feat: expose webhook push msgType stats in diagnostics
+
+EOF
+)"
+```
+
+---
+
+### Task 5: README + CHANGELOG + 全量验证
+
+**Files:**
+- Modify: `README.md`（Troubleshooting 节）
+- Modify: `CHANGELOG.md`（`[1.3.1]` Fixed）
+
+- [ ] **Step 1: Update README Troubleshooting**
+
+将现有 Event push 条目扩展为（保留原有 URL/repair 句，并追加）：
+
+```markdown
+- **Event push not working** — Check **Settings → System → Network → Home Assistant URL** (external URL required), or set a manual callback URL in **Configure**. Review repair issues under **Settings → System → Repairs**.
+  - Automations can listen to `imou_life_event` (all accepted pushes) and `imou_life_alarm` (security alarms only). Privacy-mask messages (`openCamera` / `closeCamera`) fire only `imou_life_event`.
+  - If you receive `abAlarmSound` or `closeCamera`, the callback/webhook path is working.
+  - If `videoMotion` / `human` / `mobileDetect` never appear: confirm motion/human detection is enabled on the device; download **Diagnostics** and check `event_push.recent_msg_type_counts`. Missing keys mean the cloud/device did not push those types (not an HA misclassification).
+  - Confirm event push is enabled in **Configure** and push types include **alarm**.
+```
+
+- [ ] **Step 2: Update CHANGELOG under `[1.3.1]`**
+
+在 `### Changed` 旁增加或合并：
+
+```markdown
+### Fixed
+- Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
+```
+
+若 `[1.3.1]` 尚无 `### Fixed`，新建该小节。勿改动无关 sensor changelog 措辞。
+
+- [ ] **Step 3: Full verification**
+
+```bash
+script/lint-check
+script/test
+```
+
+Expected: 全部通过
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: document webhook alarm classification and push diagnostics
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist（自检）
+
+| Spec 要求 | Task |
+|-----------|------|
+| 混合分类 / `openCamera`/`closeCamera` 非报警 | Task 1–2 |
+| 真报警仍发 `imou_life_alarm` | Task 2 |
+| `msg_type is None` 不报警 | Task 1–2 |
+| Runtime 计数 + 50 键上限 | Task 3 |
+| 过滤/关闭 push 不计数 | Task 3 |
+| Diagnostics `event_push` | Task 4 |
+| README 排查 | Task 5 |
+| 不轮询 / 不 getMessageCallback | 全计划未引入 |
+| 事件名/payload 不变 | 全计划未改 normalize 字段 |
+
+## Placeholder scan
+
+无 TBD / “类似 Task N” / 空测试步骤。

--- a/docs/superpowers/specs/2026-07-21-imou-webhook-alarm-classification-design.md
+++ b/docs/superpowers/specs/2026-07-21-imou-webhook-alarm-classification-design.md
@@ -1,0 +1,174 @@
+# Webhook 报警分类与推送可观测性 — 设计规格
+
+**日期:** 2026-07-21  
+**状态:** 已批准  
+**范围:** `Imou-Home-Assistant/custom_components/imou_life`  
+**关联:** [Imou-Home-Assistant#66](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/issues/66)  
+**决策:** 方案 2 — 混合分类 + 本地 runtime 计数 / diagnostics；不轮询、不调用 `getMessageCallback`
+
+## 摘要
+
+修复 webhook 将 `openCamera` / `closeCamera` 等非安防消息误判为 `imou_life_alarm` 的问题；同时用内存计数与 diagnostics 帮助区分「云端未推送」与「收到但分错类」，便于排查动检 / 人形漏推。不改变事件名与 payload 字段，不引入报警轮询兜底。
+
+## 问题陈述
+
+用户（Ranger 2C Pro，海外区，集成 1.3.0）报告：
+
+1. **误分类：** `closeCamera` / `openCamera` 触发了 `imou_life_alarm`（用户认为这不是报警）。
+2. **漏推：** 动检 / 人形未通过 webhook 到达；目前能稳定看到的报警类推送主要是 `abAlarmSound`。
+
+根因（误分类）：`webhook.py` 用黑名单 `_NON_ALARM_TYPES` 判定 `is_alarm = msg_type not in _NON_ALARM_TYPES`，但未包含 `openCamera` / `closeCamera`（官方文档将二者归在 Device alarm 大类，语义为隐私罩开关，不是安防报警）。现有黑名单中的 `"close"` 与实际 `msgType` `"closeCamera"` 也不匹配。
+
+漏推：集成在收到后不会按报警子类型丢弃；若未出现在 HA，更可能是设备未开启或开放平台未推送该 `msgType`。本次通过可观测性支持自证，不保证平台一定推送。
+
+参考：
+
+- [Event message type definition](https://open.imoulife.com/book/en/push/alarm.html)
+- [Event message format definition](https://open.imoulife.com/book/en/push/event.html)
+- [setMessageCallback](https://open.imoulife.com/book/en/http/push/setMessageCallback.html)
+
+## 目标
+
+1. `openCamera` / `closeCamera` 及同类状态/操作消息：只发 `imou_life_event`，不发 `imou_life_alarm`，不触发 notify。
+2. 真报警（`videoMotion`、`human`、`mobileDetect`、`abAlarmSound`、烟感等）：行为与现网一致（推送到达时两者都发）。
+3. diagnostics 可展示近期收到的 `msgType` 计数与本地 push 配置，便于回复 #66。
+4. README 补充 Event push 排查步骤。
+
+## 非目标
+
+- 不实现报警记录轮询兜底
+- 不在 pyimouapi / 本集成中调用 `getMessageCallback`
+- 不保证特定机型一定收到 `videoMotion` / `human`
+- 不改 `callbackFlag` 语义，不新增 push 类型选项
+- 不改 HA core `imou` 组件
+- 不做 breaking change：`imou_life_event` / `imou_life_alarm` 名称与 payload 字段保持不变
+- 计数不持久化、不做成实体
+
+## 架构与数据流
+
+```text
+Imou cloud POST → async_handle_imou_webhook
+  → normalize payload
+  → push_enabled? selected_devices?
+  → record runtime msgType stats
+  → bus.fire(imou_life_event)
+  → if is_alarm_msg_type(msg_type):
+        bus.fire(imou_life_alarm)
+        optional notify
+  → HTTP 200
+```
+
+判定与通知共用同一 `is_alarm` 结果。
+
+## §1 报警分类（混合）
+
+### 规则
+
+```text
+is_alarm = msg_type is not None and msg_type not in NON_ALARM_MSG_TYPES
+```
+
+- 默认：未知 `msgType` **算报警**（避免漏报新安防类型）。
+- `msg_type is None`：**不算报警**（避免脏 payload）。
+
+将现有 `_NON_ALARM_TYPES` 重命名/扩展为 `NON_ALARM_MSG_TYPES`（或等价私有常量），并抽出 `_is_alarm_msg_type(msg_type: str | None) -> bool`，供 handler 与测试使用。常量旁注释指向官方类型文档。
+
+### `NON_ALARM_MSG_TYPES` 至少包含
+
+| 类别 | msgType |
+|------|---------|
+| 设备状态（原有） | `online`, `offline`, `close`, `changeDevName` |
+| IoT / 统计（原有） | `iotEvent`, `iotProperty`, `iotAction`, `numberstat` |
+| 隐私罩（#66） | `openCamera`, `closeCamera` |
+| 灯光 / 警笛状态 | `whiteLightOn`, `whiteLightOff`, `sirenOn`, `sirenOff` |
+| 休眠 | `sleep` |
+| 绑定 / 分享 / 授权 / 转移 | `bindDevice`, `unbindDevice`, `deviceShare`, `deviceShareCancel`, `deviceAuthorize`, `deviceAuthorizationChanged`, `transferDeviceFrom`, `transferDeviceTo`, `deviceDeletedSharedCancel` |
+| 升级 / 存储运维 | `UpgradeSuccess`, `upgradeFail`, `apUpgradeSuccess`, `apUpgradeFail`, `storageRecoverOk`, `storageRecoverFail`, `storageEmpty`, `storageAbnormal` |
+
+**刻意保留为报警（不进黑名单）：** `videoMotion`, `human`, `mobileDetect`, `abAlarmSound`, 以及烟感 / 燃气 / 门磁等安防类。
+
+实现时可按上表一次写入完整 frozenset；后续若 issue 再报误分类，只扩黑名单。
+
+### 事件行为
+
+1. 通过 push 开关与设备过滤后 → 一律 `imou_life_event`
+2. `is_alarm` → 额外 `imou_life_alarm`
+3. `is_alarm` 且配置了 notify → 发通知
+
+## §2 可观测性与文档
+
+### Runtime 计数
+
+在 `ImouRuntimeData` 增加（进程内、不落盘）：
+
+| 字段 | 含义 |
+|------|------|
+| `push_msg_type_counts: dict[str, int]` | 按 `msgType` 累加（含非报警） |
+| `push_last_msg_type: str \| None` | 最近一次成功处理的类型 |
+| `push_last_received_at: datetime \| None` | 最近一次成功处理时间（UTC） |
+
+约束：
+
+- 不同 `msgType` 键数上限 **50**；超出时计入 `"_other"`。
+- 仅在通过 `push_enabled` 与设备过滤之后、准备/已经 `async_fire(EVENT_IMOU_EVENT)` 时更新。
+- push 关闭或设备被过滤：**不计入**。
+
+### Diagnostics
+
+`async_get_config_entry_diagnostics` 增补（脱敏策略不变）：
+
+```text
+event_push:
+  enabled: bool
+  webhook_url_configured: bool
+  event_push_types: list
+  base_push: str
+  selected_devices_count: int
+  recent_msg_type_counts: dict
+  last_msg_type: str | null
+  last_received_at: str | null   # ISO8601 或 null
+```
+
+`runtime_data` 缺失时上述计数字段给空默认值，不抛错。不调用云端 callback 查询 API。
+
+### README
+
+在 Troubleshooting 增加 Event push 要点：
+
+1. 自动化可同时监听 `imou_life_event` 与 `imou_life_alarm`；隐私罩开关只应出现在前者。
+2. 能收到 `abAlarmSound` / `closeCamera` 说明 callback / webhook 通路正常。
+3. 若始终没有 `videoMotion` / `human` / `mobileDetect`：检查设备端动检/人形开关；下载 diagnostics 查看 `recent_msg_type_counts`——若从未出现，属云端/设备未推，非 HA 分类问题。
+4. 确认 Options 中 event push 已启用，且类型包含 `alarm`。
+
+## §3 错误处理与边界
+
+- Webhook 始终 HTTP 200；非法 JSON / 非 dict：不更新计数、不发事件。
+- notify 失败：打日志，不影响事件与 200。
+- 改动文件：`webhook.py`、`runtime_data.py`、`diagnostics.py`、`tests/test_webhook.py`、`tests/test_diagnostics.py`、`README.md`（必要时 `CHANGELOG.md` 在实现计划中单独列出）。
+- 黑名单手工维护，不爬取官方页面。
+
+## 测试计划
+
+| 用例 | 期望 |
+|------|------|
+| `closeCamera` / `openCamera` | 有 `imou_life_event`，无 `imou_life_alarm`，不调 notify |
+| `videoMotion` / `human` / `abAlarmSound` | 两者都有 |
+| `iotProperty` | 保持现有：仅 generic event |
+| `msgType` 缺失 | 发 `imou_life_event`，不发 `imou_life_alarm` |
+| diagnostics | webhook 处理后含 `recent_msg_type_counts` |
+| 未选中设备 / push 关闭 | 无事件、计数不增加 |
+
+## 成功标准
+
+1. #66 描述的误分类在单测与行为上已修复。
+2. 真报警类型在推送到达时行为不变。
+3. diagnostics 能支撑「是否收到某 msgType」的排查。
+4. `script/lint-check` 与 `script/test` 通过。
+
+## 实现顺序（供后续 plan）
+
+1. 扩展 `NON_ALARM_MSG_TYPES` + `_is_alarm_msg_type`，改 handler 判定
+2. Runtime 计数字段 + webhook 更新
+3. Diagnostics 输出
+4. 测试
+5. README（+ 实现阶段再定是否写 CHANGELOG）

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from custom_components.imou_life.const import DOMAIN, PARAM_WEBHOOK_ID
+from custom_components.imou_life.const import (
+    DOMAIN,
+    PARAM_BASE_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
+    PARAM_WEBHOOK_ID,
+)
 from custom_components.imou_life.diagnostics import async_get_config_entry_diagnostics
 from custom_components.imou_life.runtime_data import ImouRuntimeData
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -34,3 +39,39 @@ async def test_diagnostics_redacts_secrets(hass) -> None:
     assert result["event_push_enabled"] is True
     assert result["last_update_success"] is True
     assert "pyimouapi_version" in result
+    assert result["event_push"]["enabled"] is True
+    assert result["event_push"]["recent_msg_type_counts"] == {}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_diagnostics_includes_push_msg_counts(hass) -> None:
+    """Diagnostics expose runtime push msgType counters."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**USER_INPUT, PARAM_WEBHOOK_ID: "abcd1234efgh5678"},
+        options={
+            "enable_event_push": True,
+            PARAM_EVENT_PUSH_TYPES: ["alarm", "device_status"],
+            PARAM_BASE_PUSH: "2",
+            "webhook_url": "https://example.com/hook",
+        },
+    )
+    entry.add_to_hass(hass)
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    runtime.record_push_msg("closeCamera")
+    runtime.record_push_msg("abAlarmSound")
+    entry.runtime_data = runtime
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    event_push = result["event_push"]
+
+    assert event_push["enabled"] is True
+    assert event_push["webhook_url_configured"] is True
+    assert event_push["event_push_types"] == ["alarm", "device_status"]
+    assert event_push["base_push"] == "2"
+    assert event_push["recent_msg_type_counts"] == {
+        "closeCamera": 1,
+        "abAlarmSound": 1,
+    }
+    assert event_push["last_msg_type"] == "abAlarmSound"
+    assert event_push["last_received_at"] is not None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 import pytest
 from custom_components.imou_life.const import (
     DOMAIN,
-    PARAM_BASE_PUSH,
     PARAM_EVENT_PUSH_TYPES,
     PARAM_WEBHOOK_ID,
 )
@@ -52,7 +51,6 @@ async def test_diagnostics_includes_push_msg_counts(hass) -> None:
         options={
             "enable_event_push": True,
             PARAM_EVENT_PUSH_TYPES: ["alarm", "device_status"],
-            PARAM_BASE_PUSH: "2",
             "webhook_url": "https://example.com/hook",
         },
     )
@@ -68,7 +66,7 @@ async def test_diagnostics_includes_push_msg_counts(hass) -> None:
     assert event_push["enabled"] is True
     assert event_push["webhook_url_configured"] is True
     assert event_push["event_push_types"] == ["alarm", "device_status"]
-    assert event_push["base_push"] == "2"
+    assert event_push["base_push"] == "1"
     assert event_push["recent_msg_type_counts"] == {
         "closeCamera": 1,
         "abAlarmSound": 1,

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from custom_components.imou_life.const import (
     EVENT_IMOU_ALARM,
     EVENT_IMOU_EVENT,
 )
+from custom_components.imou_life.runtime_data import ImouRuntimeData
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
     _is_alarm_msg_type,
@@ -279,3 +281,67 @@ async def test_webhook_missing_msg_type_is_not_alarm(
     assert response.status == 200
     assert len(generic_events) == 1
     assert alarm_events == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_records_msg_type_counts(hass: HomeAssistant) -> None:
+    """Accepted pushes increment runtime msgType counters."""
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "abAlarmSound", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts["closeCamera"] == 2
+    assert runtime.push_msg_type_counts["abAlarmSound"] == 1
+    assert runtime.push_last_msg_type == "abAlarmSound"
+    assert runtime.push_last_received_at is not None
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_filtered_device_does_not_count(
+    hass: HomeAssistant,
+) -> None:
+    """Unselected devices do not update push counters."""
+    runtime = setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["selected_device"],
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "alarmLocal", "deviceId": "other_device"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts == {}
+    assert runtime.push_last_msg_type is None
+
+
+def test_record_push_msg_caps_distinct_keys() -> None:
+    """More than 50 distinct msgTypes fold into _other."""
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    for i in range(50):
+        runtime.record_push_msg(f"type_{i}")
+    assert len(runtime.push_msg_type_counts) == 50
+    runtime.record_push_msg("type_extra")
+    assert runtime.push_msg_type_counts["_other"] == 1
+    assert "type_extra" not in runtime.push_msg_type_counts
+    assert runtime.push_last_msg_type == "type_extra"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -14,6 +14,7 @@ from custom_components.imou_life.runtime_data import ImouRuntimeData
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
     _is_alarm_msg_type,
+    _normalize_event_payload,
     async_handle_imou_webhook,
 )
 from homeassistant.core import Event, HomeAssistant
@@ -181,13 +182,18 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
         ("openCamera", False),
         ("online", False),
         ("iotProperty", False),
+        ("iotAction", False),
+        ("iotEvent", True),
         ("whiteLightOn", False),
+        ("sirenOn", True),
+        ("sirenOff", True),
         ("bindDevice", False),
         ("videoMotion", True),
         ("human", True),
         ("abAlarmSound", True),
         ("mobileDetect", True),
         ("alarmLocal", True),
+        ("33000", True),
         ("totallyUnknownType", True),
         (None, False),
     ],
@@ -195,6 +201,67 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
     """Hybrid classification: denylist non-alarms; unknown types are alarms."""
     assert _is_alarm_msg_type(msg_type) is expected
+
+
+def test_normalize_iot_event_promotes_content_fields() -> None:
+    """iotEvent pushes expose content.event as msg_type plus pid/outputData."""
+    event = _normalize_event_payload(
+        {
+            "msgType": "iotEvent",
+            "pid": "mhpf7Dsz",
+            "did": "TESTQWERXXXX",
+            "dname": "Gate",
+            "alarmId": "116257862023505xxxx",
+            "token": "tok",
+            "time": "20230111T111629",
+            "content": {
+                "outputData": {"foo": 1},
+                "event": "33000",
+                "monitor": {"channel": 0, "action": 1},
+            },
+        }
+    )
+
+    assert event["msg_type"] == "33000"
+    assert event["msg_type_name"] == "33000"
+    assert event["product_id"] == "mhpf7Dsz"
+    assert event["device_id"] == "TESTQWERXXXX"
+    assert event["channel_id"] == 0
+    assert event["alarm_id"] == "116257862023505xxxx"
+    assert event["outputData"] == {"foo": 1}
+    assert event["raw"]["msgType"] == "iotEvent"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_iot_event_fires_alarm(hass: HomeAssistant) -> None:
+    """Normalized iotEvent content.event fires imou_life_alarm."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["TESTQWERXXXX"])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": "iotEvent",
+                "pid": "mhpf7Dsz",
+                "did": "TESTQWERXXXX",
+                "dname": "Gate",
+                "content": {"event": "33000", "outputData": {"bar": 2}},
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 1
+    assert alarm_events[0].data["msg_type"] == "33000"
+    assert alarm_events[0].data["product_id"] == "mhpf7Dsz"
+    assert alarm_events[0].data["outputData"] == {"bar": 2}
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -286,9 +286,7 @@ async def test_webhook_missing_msg_type_is_not_alarm(
 @pytest.mark.usefixtures("enable_custom_integrations")
 async def test_webhook_records_msg_type_counts(hass: HomeAssistant) -> None:
     """Accepted pushes increment runtime msgType counters."""
-    runtime = setup_imou_runtime(
-        hass, push_enabled=True, selected_devices=["device_1"]
-    )
+    runtime = setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
 
     await async_handle_imou_webhook(
         hass,

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -11,6 +11,7 @@ from custom_components.imou_life.const import (
 )
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
+    _is_alarm_msg_type,
     async_handle_imou_webhook,
 )
 from homeassistant.core import Event, HomeAssistant
@@ -169,3 +170,26 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 
     assert title == "Imou alarm: Local alarm"
     assert message == "Device: Front Door\nType: Local alarm"
+
+
+@pytest.mark.parametrize(
+    ("msg_type", "expected"),
+    [
+        ("closeCamera", False),
+        ("openCamera", False),
+        ("online", False),
+        ("iotProperty", False),
+        ("whiteLightOn", False),
+        ("bindDevice", False),
+        ("videoMotion", True),
+        ("human", True),
+        ("abAlarmSound", True),
+        ("mobileDetect", True),
+        ("alarmLocal", True),
+        ("totallyUnknownType", True),
+        (None, False),
+    ],
+)
+def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
+    """Hybrid classification: denylist non-alarms; unknown types are alarms."""
+    assert _is_alarm_msg_type(msg_type) is expected

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from custom_components.imou_life.const import (
@@ -14,6 +14,7 @@ from custom_components.imou_life.runtime_data import ImouRuntimeData
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
     _is_alarm_msg_type,
+    _load_webhook_strings_file,
     _normalize_event_payload,
     async_handle_imou_webhook,
 )
@@ -173,6 +174,22 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 
     assert title == "Imou alarm: Local alarm"
     assert message == "Device: Front Door\nType: Local alarm"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_strings_load_via_executor(hass: HomeAssistant) -> None:
+    """Webhook string files must not be read on the event loop (HA blocking I/O)."""
+    _load_webhook_strings_file.cache_clear()
+    with patch.object(
+        hass, "async_add_executor_job", wraps=hass.async_add_executor_job
+    ) as mock_executor:
+        await _async_build_notification_message(
+            hass,
+            {"msg_type": "alarmLocal", "name": "Front Door"},
+        )
+
+    assert mock_executor.call_count >= 1
+    assert mock_executor.call_args.args[0] is _load_webhook_strings_file
 
 
 @pytest.mark.parametrize(

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -193,3 +193,89 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
     """Hybrid classification: denylist non-alarms; unknown types are alarms."""
     assert _is_alarm_msg_type(msg_type) is expected
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["closeCamera", "openCamera"])
+async def test_webhook_privacy_mask_is_not_alarm(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Privacy mask open/close fires generic event only."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["device_1"],
+        notify_services=["notify.test"],
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": msg_type,
+                "did": "device_1",
+                "cid": 0,
+                "dname": "Cam",
+                "time": 1783528060,
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert generic_events[0].data["msg_type"] == msg_type
+    assert alarm_events == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["videoMotion", "human", "abAlarmSound"])
+async def test_webhook_security_alarms_fire_alarm_event(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Security alarm msgTypes fire both generic and alarm events."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": msg_type, "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 1
+    assert alarm_events[0].data["msg_type"] == msg_type
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_missing_msg_type_is_not_alarm(
+    hass: HomeAssistant,
+) -> None:
+    """Payload without msgType still fires generic event, not alarm."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert alarm_events == []


### PR DESCRIPTION
## Summary

Fixes #66 (and related webhook push follow-ups on this branch).

- Classify privacy-mask / status / ops webhook `msgType`s (`openCamera`, `closeCamera`, …) as `imou_life_event` only — not `imou_life_alarm` — so automations and notify are not misfired.
- Treat `iotEvent` / `sirenOn` / `sirenOff` as alarms; promote `content.event` to `msg_type` and expose `product_id` / `outputData` on the HA event.
- Always sync event push to the Imou app (`basePush=1`); remove the Base push Configure option.
- Track recent webhook `msgType` counts on runtime data and expose them in diagnostics for push observability.
- Load webhook i18n strings via executor to avoid MainThread blocking warnings under concurrent pushes.
- Bug report template: guide reporters to enable `imou_life` / `pyimouapi` debug and paste API `code`/`msg`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code quality / tests / documentation only

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] Local `script/lint-check` and `script/test` pass.
- [ ] I have manually verified the changed behavior in Home Assistant (see **Testing** below).
- [x] New behavior has tests; bugfixes include regression tests where applicable.
- [x] No commented-out dead code.
- [x] If `manifest.json` changed: version bumped and `CHANGELOG.md` updated.
- [x] If user-facing strings changed: `translations/` updated.
- [ ] If dependencies changed: version pin updated with changelog link in this description.
- [ ] GitHub Actions checks are green (CI runs automatically on fork PRs; mark **Ready for review** if this was a draft).

### AI-assisted contributions

- [x] AI tools were used in this PR (Copilot, Cursor, ChatGPT, etc.).
- [x] I have reviewed every AI-generated line and can explain it without relying on the tool.

## Test plan

- [ ] Enable event push; trigger privacy mask open/close → only `imou_life_event`, no alarm notify
- [ ] Trigger a real alarm (e.g. motion / human / `abAlarmSound`) → `imou_life_alarm` + notify if configured
- [ ] Trigger IoT / siren-related pushes → classified as alarm with enriched fields where applicable
- [ ] Download diagnostics → `event_push.recent_msg_type_counts` reflects recent pushes
- [ ] Confirm Imou mobile app still receives pushes after Configure (no Base push toggle)
- [ ] Under concurrent webhook traffic, no HA “detected blocking call” warning from webhook string loading
- [ ] Unit: `tests/test_webhook.py`, `tests/test_diagnostics.py`

## Additional notes

- Design / plan: `docs/superpowers/specs/2026-07-21-imou-webhook-alarm-classification-design.md` and the matching implementation plan under `docs/superpowers/plans/`.
- `CHANGELOG.md` updated for 1.3.1 notes on this branch; `manifest.json` version bump may still be pending release packaging.