### PR TITLE
release: Imou Life 1.3.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,12 @@ labels: bug
 
 ## What happened?
 
+
 ## Steps to reproduce
 
+
 ## Expected behavior
+
 
 ## Environment
 
@@ -21,6 +24,34 @@ labels: bug
 
 ## Logs
 
+Please enable **debug** logging, reproduce the issue once, then paste the relevant log lines as **text** (not only screenshots).
+
+### Enable debug logging
+
+**Option A — temporary (UI)**  
+1. **Settings → System → Logs**  
+2. Three-dot menu (⋮) → set log level / enable debug  
+3. Set these to **debug**:
+   - `custom_components.imou_life`
+   - `pyimouapi`
+
+**Option B — persistent (`configuration.yaml`)**  
+Then restart Home Assistant:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.imou_life: debug
+    pyimouapi: debug
+```
+
+### What to paste
+
+Search logs for `pyimouapi` / `imou_life` (and for setup failures: `listDeviceDetails`). Prefer lines like `url: ... request body: ... response: ...` that show the API `code` / `msg`.
+
+**Redact** `accessToken` / `token` and any secrets before posting. AppId, API host, and result `code`/`msg` can stay visible.
+
 ```text
-Paste relevant logs here (debug level recommended)
+Paste relevant debug logs here
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, `electricity`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
 - Preserve empty `selected_devices` (do not treat `[]` as unset); close Open API client on unload; persist device removal into `selected_devices` so poll does not re-add it
+- Webhook notify/events prefer HA device registry name (`device_name`) over push `cname`/`dname`
 
 ## [1.3.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, `electricity`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
+- Preserve empty `selected_devices` (do not treat `[]` as unset); close Open API client on unload; persist device removal into `selected_devices` so poll does not re-add it
 
 ## [1.3.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [1.3.1]
+### Fixed
+- Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
+
 ## [1.3.0]
 ### Added
 - Reauth flow when App Secret expires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, `electricity`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
 - Preserve empty `selected_devices` (do not treat `[]` as unset); close Open API client on unload; persist device removal into `selected_devices` so poll does not re-add it
 - Webhook notify/events prefer HA device registry name (`device_name`) over push `cname`/`dname`
+- Webhook ACKs HTTP 200 before identifier resolve/notify; refuse device removal when the coordinator map cannot safely materialize an allow-list
 
 ## [1.3.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 ## [1.3.1]
 ### Changed
 - Event push always syncs to the Imou app (`basePush=1`); removed the Base push option from Configure
-- Webhook `iotEvent`: promote `content.event` to `msg_type`; expose `product_id` (`pid`) and `outputData`; treat `iotEvent` / `sirenOn` / `sirenOff` as alarms
+- Webhook `msg_type` uses top-level `msgType` only; still expose `product_id` (`pid`) and `outputData`; treat `iotEvent` / `sirenOn` / `sirenOff` as alarms
+- Webhook: resolve numeric / `iotEvent` push types to product-model event identifiers via pyimouapi 1.3.1 (alarm classification still uses top-level `msgType`)
+- Depend on `pyimouapi==1.3.1`
 
 ### Fixed
-- Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
+- Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, `electricity`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
 
 ## [1.3.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 ## [1.3.1]
+### Changed
+- Event push always syncs to the Imou app (`basePush=1`); removed the Base push option from Configure
+
 ### Fixed
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### Changed
 - Event push always syncs to the Imou app (`basePush=1`); removed the Base push option from Configure
 - Webhook `msg_type` uses top-level `msgType` only; still expose `product_id` (`pid`) and `outputData`; treat `iotEvent` / `sirenOn` / `sirenOff` as alarms
-- Webhook: resolve numeric / `iotEvent` push types to product-model event identifiers via pyimouapi 1.3.1 (alarm classification still uses top-level `msgType`)
-- Depend on `pyimouapi==1.3.1`
+- Webhook: resolve numeric / `iotEvent` push types to product-model event identifiers via pyimouapi 1.3.2 (alarm classification still uses top-level `msgType`)
+- Depend on `pyimouapi==1.3.2`
 
 ### Fixed
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, `electricity`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [1.3.1]
 ### Changed
 - Event push always syncs to the Imou app (`basePush=1`); removed the Base push option from Configure
+- Webhook `iotEvent`: promote `content.event` to `msg_type`; expose `product_id` (`pid`) and `outputData`; treat `iotEvent` / `sirenOn` / `sirenOff` as alarms
 
 ### Fixed
 - Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ Devices under your Imou account should appear in Home Assistant. Use **Configure
 
 - **Invalid AppId / AppSecret** — Home Assistant opens a **re-authentication** flow; enter a new App Secret under **Settings → Devices & services → Imou Life** (notification or three-dot menu → **Re-authenticate**).
 - **Event push not working** — Check **Settings → System → Network → Home Assistant URL** (external URL required), or set a manual callback URL in **Configure**. Review repair issues under **Settings → System → Repairs**.
+  - Automations can listen to `imou_life_event` (all accepted pushes) and `imou_life_alarm` (security alarms only). Privacy-mask messages (`openCamera` / `closeCamera`) fire only `imou_life_event`.
+  - If you receive `abAlarmSound` or `closeCamera`, the callback/webhook path is working.
+  - If `videoMotion` / `human` / `mobileDetect` never appear: confirm motion/human detection is enabled on the device; download **Diagnostics** and check `event_push.recent_msg_type_counts`. Missing keys mean the cloud/device did not push those types (not an HA misclassification).
+  - Confirm event push is enabled in **Configure** and push types include **alarm**.
 - **Automations after upgrade** — v1.3.0 removes custom `imou_life.turn_on` / `turn_off` / `select` services; use standard `switch.turn_on`, `select.select_option`, and `button.press`.
 - **Diagnostics** — Download redacted diagnostics from the integration's **Download diagnostics** (three-dot menu on the config entry).
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Devices under your Imou account should appear in Home Assistant. Use **Configure
   - Optional webhook callback for real-time messages from Imou cloud (requires public HA URL or manual callback URL)
   - Home Assistant events: `imou_life_event` (all accepted pushes), `imou_life_alarm` (alarm-type only)
   - Optional notify services for alarm messages
-  - Choose push message types; sync to Imou mobile app or HA-only
+  - Choose push message types; messages are also synced to the Imou mobile app
 * **Camera Function Management**
   - Information and status display (device name, online status, storage status, battery level, etc.)
   - Live video preview

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -7,22 +7,24 @@ import uuid
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 from pyimouapi.device import ImouDeviceManager
 from pyimouapi.ha_device import ImouHaDeviceManager
 from pyimouapi.openapi import ImouOpenApiClient
 
 from .const import (
+    DOMAIN,
     PARAM_API_URL,
     PARAM_APP_ID,
     PARAM_APP_SECRET,
     PARAM_ENABLE_EVENT_PUSH,
+    PARAM_SELECTED_DEVICES,
     PARAM_WEBHOOK_ID,
     PLATFORMS,
 )
 from .coordinator import ImouConfigEntry, ImouDataUpdateCoordinator
 from .event_push import async_setup_event_push, async_teardown_event_push
+from .helpers import get_selected_device_ids
 from .runtime_data import ImouRuntimeData
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -72,6 +74,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ImouConfigEntry) -> bool
 
     entry.async_on_unload(coordinator.async_add_listener(_async_keep_polling))
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
+
+    async def _async_close_client() -> None:
+        await imou_client.async_close()
+
+    entry.async_on_unload(_async_close_client)
     return True
 
 
@@ -83,17 +90,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ImouConfigEntry) -> boo
 
     webhook_id = entry.data.get(PARAM_WEBHOOK_ID, "")
     if entry.options.get(PARAM_ENABLE_EVENT_PUSH) and webhook_id:
-        imou_client = ImouOpenApiClient(
+        teardown_client = ImouOpenApiClient(
             entry.data[PARAM_APP_ID],
             entry.data[PARAM_APP_SECRET],
             entry.data[PARAM_API_URL],
         )
         try:
-            await async_teardown_event_push(hass, entry, imou_client)
+            await async_teardown_event_push(hass, entry, teardown_client)
         except Exception:
             _LOGGER.exception("Failed to disable Imou message callback during unload")
         finally:
-            await imou_client.async_close()
+            await teardown_client.async_close()
     elif webhook_id:
         await async_teardown_event_push(hass, entry)
 
@@ -106,10 +113,48 @@ async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await hass.config_entries.async_reload(entry.entry_id)
 
 
+def _device_id_from_entry(device_entry: DeviceEntry) -> str | None:
+    """Extract Imou device_id from a HA device registry entry."""
+    if device_entry.serial_number:
+        return device_entry.serial_number
+    for domain, ident in device_entry.identifiers:
+        if domain == DOMAIN:
+            return ident.split("_", 1)[0]
+    return None
+
+
 async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
 ) -> bool:
-    """Handle removal of a single device from a config entry."""
-    _LOGGER.debug("Removing device %s", device_entry.name)
-    dr.async_get(hass).async_remove_device(device_entry.id)
+    """Persist exclusion so the next poll does not re-add the device."""
+    device_id = _device_id_from_entry(device_entry)
+    if not device_id:
+        _LOGGER.warning(
+            "Cannot remove device %s: missing Imou device id", device_entry.name
+        )
+        return False
+
+    selected = get_selected_device_ids(config_entry)
+    if selected is None:
+        runtime = getattr(config_entry, "runtime_data", None)
+        if runtime is None:
+            _LOGGER.warning(
+                "Cannot remove device %s: no runtime to materialize selected_devices",
+                device_entry.name,
+            )
+            return False
+        all_ids = {d.device_id for d in runtime.coordinator.devices_by_key.values()}
+        selected = [i for i in sorted(all_ids) if i != device_id]
+    else:
+        selected = [i for i in selected if i != device_id]
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={**config_entry.options, PARAM_SELECTED_DEVICES: selected},
+    )
+    runtime = getattr(config_entry, "runtime_data", None)
+    if runtime is not None:
+        runtime.selected_devices = selected
+
+    _LOGGER.debug("Removed device %s from selected_devices", device_id)
     return True

--- a/custom_components/imou_life/__init__.py
+++ b/custom_components/imou_life/__init__.py
@@ -144,6 +144,12 @@ async def async_remove_config_entry_device(
             )
             return False
         all_ids = {d.device_id for d in runtime.coordinator.devices_by_key.values()}
+        if not all_ids or device_id not in all_ids:
+            _LOGGER.warning(
+                "Cannot remove device %s: coordinator device map incomplete",
+                device_entry.name,
+            )
+            return False
         selected = [i for i in sorted(all_ids) if i != device_id]
     else:
         selected = [i for i in selected if i != device_id]

--- a/custom_components/imou_life/config_flow.py
+++ b/custom_components/imou_life/config_flow.py
@@ -384,12 +384,13 @@ class ImouOptionsFlow(OptionsFlow):
                 errors=errors,
             )
 
-        # Preselect currently active devices
-        current_selected = (
-            self.config_entry.options.get(PARAM_SELECTED_DEVICES)
-            or self.config_entry.data.get(PARAM_SELECTED_DEVICES)
-            or list(self._devices_map.keys())
-        )
+        # Preselect currently active devices (preserve explicit empty selection)
+        if PARAM_SELECTED_DEVICES in self.config_entry.options:
+            current_selected = self.config_entry.options[PARAM_SELECTED_DEVICES]
+        elif PARAM_SELECTED_DEVICES in self.config_entry.data:
+            current_selected = self.config_entry.data[PARAM_SELECTED_DEVICES]
+        else:
+            current_selected = list(self._devices_map.keys())
 
         return self.async_show_form(
             step_id="devices",

--- a/custom_components/imou_life/config_flow.py
+++ b/custom_components/imou_life/config_flow.py
@@ -291,7 +291,7 @@ class ImouOptionsFlow(OptionsFlow):
         not_set_use_suggested = _options_placeholder(
             self.hass,
             "not_set_use_suggested",
-            "Not set — the suggested URL above will be used",
+            "Not set — will use the suggested URL above",
         )
 
         suggested_options = dict(self.config_entry.options)

--- a/custom_components/imou_life/config_flow.py
+++ b/custom_components/imou_life/config_flow.py
@@ -33,14 +33,12 @@ from .const import (
     CONF_HTTP,
     CONF_HTTPS,
     CONF_SD,
-    DEFAULT_BASE_PUSH,
     DEFAULT_EVENT_PUSH_TYPES,
     DOMAIN,
     EVENT_PUSH_TYPE_OPTIONS,
     PARAM_API_URL,
     PARAM_APP_ID,
     PARAM_APP_SECRET,
-    PARAM_BASE_PUSH,
     PARAM_DOWNLOAD_SNAP_WAIT_TIME,
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
@@ -333,14 +331,6 @@ class ImouOptionsFlow(OptionsFlow):
                                 options=list(EVENT_PUSH_TYPE_OPTIONS),
                                 multiple=True,
                                 translation_key="event_push_type",
-                            )
-                        ),
-                        vol.Required(
-                            PARAM_BASE_PUSH, default=DEFAULT_BASE_PUSH
-                        ): SelectSelector(
-                            SelectSelectorConfig(
-                                options=["1", "2"],
-                                translation_key="base_push",
                             )
                         ),
                         # --- Notification settings ---

--- a/custom_components/imou_life/const.py
+++ b/custom_components/imou_life/const.py
@@ -41,8 +41,9 @@ PARAM_WEBHOOK_URL = "webhook_url"
 PARAM_SELECTED_DEVICES = "selected_devices"
 PARAM_ENABLE_EVENT_PUSH = "enable_event_push"
 PARAM_EVENT_PUSH_TYPES = "event_push_types"
-PARAM_BASE_PUSH = "base_push"
 PARAM_NOTIFY_SERVICES = "notify_services"
+# Always sync pushes to the Imou app as well as HA (setMessageCallback basePush).
+BASE_PUSH_ALWAYS = "1"
 PARAM_MOTION_DETECT = "motion_detect"
 PARAM_STATUS = "status"
 PARAM_STORAGE_USED = "storage_used"
@@ -137,7 +138,6 @@ def callback_flags_to_event_push_types(flags: list[str]) -> list[str]:
 
 EVENT_IMOU_EVENT = f"{DOMAIN}_event"
 EVENT_IMOU_ALARM = f"{DOMAIN}_alarm"
-DEFAULT_BASE_PUSH = "2"
 
 # service
 SERVICE_CONTROL_MOVE_PTZ = "control_move_ptz"

--- a/custom_components/imou_life/const.py
+++ b/custom_components/imou_life/const.py
@@ -9,7 +9,30 @@ UPDATE_TIMEOUT = 300
 
 def imou_life_device_key(device: ImouHaDevice) -> str:
     """Stable device registry / unique_id prefix (legacy semantics)."""
-    return f"{device.device_id}_{device.channel_id or device.product_id}"
+    key = imou_life_device_key_from_ids(
+        device.device_id, device.channel_id, device.product_id
+    )
+    if key is None:
+        return f"{device.device_id}_{device.channel_id or device.product_id}"
+    return key
+
+
+def imou_life_device_key_from_ids(
+    device_id: str | None,
+    channel_id: object | None,
+    product_id: str | None,
+) -> str | None:
+    """Build the device registry identifier key from push / API ids.
+
+    Same format as ``imou_life_device_key``: ``{device_id}_{channel_id|product_id}``.
+    Uses ``is not None`` for channel so channel 0 is kept.
+    """
+    if not device_id:
+        return None
+    suffix = channel_id if channel_id is not None else product_id
+    if suffix is None:
+        return None
+    return f"{device_id}_{suffix}"
 
 
 # Configuration definitions

--- a/custom_components/imou_life/coordinator.py
+++ b/custom_components/imou_life/coordinator.py
@@ -17,11 +17,11 @@ from pyimouapi.ha_device import ImouHaDevice, ImouHaDeviceManager
 
 from .const import (
     DOMAIN,
-    PARAM_SELECTED_DEVICES,
     PARAM_UPDATE_INTERVAL,
     UPDATE_TIMEOUT,
     imou_life_device_key,
 )
+from .helpers import get_selected_device_ids
 from .runtime_data import ImouRuntimeData
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,13 +67,7 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
     def _filter_devices(self, devices_list: list[ImouHaDevice]) -> list[ImouHaDevice]:
         """Apply selected-devices filter from config entry options or data."""
-        if PARAM_SELECTED_DEVICES in self.config_entry.options:
-            selected_ids = self.config_entry.options[PARAM_SELECTED_DEVICES]
-        elif PARAM_SELECTED_DEVICES in self.config_entry.data:
-            selected_ids = self.config_entry.data[PARAM_SELECTED_DEVICES]
-        else:
-            selected_ids = None
-
+        selected_ids = get_selected_device_ids(self.config_entry)
         if selected_ids is None:
             return devices_list
         if selected_ids:

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -9,10 +9,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import (
-    DEFAULT_BASE_PUSH,
+    BASE_PUSH_ALWAYS,
     PARAM_API_URL,
     PARAM_APP_ID,
-    PARAM_BASE_PUSH,
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
     PARAM_SELECTED_DEVICES,
@@ -48,7 +47,7 @@ async def async_get_config_entry_diagnostics(
         "enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
         "webhook_url_configured": bool(webhook_url),
         "event_push_types": list(entry.options.get(PARAM_EVENT_PUSH_TYPES, [])),
-        "base_push": entry.options.get(PARAM_BASE_PUSH, DEFAULT_BASE_PUSH),
+        "base_push": BASE_PUSH_ALWAYS,
         "selected_devices_count": len(selected),
         "recent_msg_type_counts": (
             dict(runtime.push_msg_type_counts) if runtime is not None else {}

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -14,10 +14,10 @@ from .const import (
     PARAM_APP_ID,
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
-    PARAM_SELECTED_DEVICES,
     PARAM_WEBHOOK_ID,
     PARAM_WEBHOOK_URL,
 )
+from .helpers import get_selected_device_ids
 
 
 async def async_get_config_entry_diagnostics(
@@ -27,9 +27,8 @@ async def async_get_config_entry_diagnostics(
     app_id = entry.data.get(PARAM_APP_ID, "")
     webhook_id = entry.data.get(PARAM_WEBHOOK_ID, "")
     webhook_url = entry.options.get(PARAM_WEBHOOK_URL, "")
-    selected = entry.options.get(PARAM_SELECTED_DEVICES) or entry.data.get(
-        PARAM_SELECTED_DEVICES, []
-    )
+    selected = get_selected_device_ids(entry)
+    selected_count = None if selected is None else len(selected)
 
     runtime = entry.runtime_data
     coordinator = runtime.coordinator if runtime is not None else None
@@ -48,7 +47,7 @@ async def async_get_config_entry_diagnostics(
         "webhook_url_configured": bool(webhook_url),
         "event_push_types": list(entry.options.get(PARAM_EVENT_PUSH_TYPES, [])),
         "base_push": BASE_PUSH_ALWAYS,
-        "selected_devices_count": len(selected),
+        "selected_devices_count": selected_count,
         "recent_msg_type_counts": (
             dict(runtime.push_msg_type_counts) if runtime is not None else {}
         ),
@@ -59,7 +58,7 @@ async def async_get_config_entry_diagnostics(
     return {
         "app_id": f"{app_id[:4]}…" if len(app_id) > 4 else app_id,
         "api_url": entry.data.get(PARAM_API_URL),
-        "selected_devices_count": len(selected),
+        "selected_devices_count": selected_count,
         "event_push_enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
         "webhook_id": f"{webhook_id[:8]}…" if len(webhook_id) > 8 else webhook_id,
         "webhook_url_configured": bool(webhook_url),

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -53,9 +53,7 @@ async def async_get_config_entry_diagnostics(
         "recent_msg_type_counts": (
             dict(runtime.push_msg_type_counts) if runtime is not None else {}
         ),
-        "last_msg_type": (
-            runtime.push_last_msg_type if runtime is not None else None
-        ),
+        "last_msg_type": (runtime.push_last_msg_type if runtime is not None else None),
         "last_received_at": last_received,
     }
 

--- a/custom_components/imou_life/diagnostics.py
+++ b/custom_components/imou_life/diagnostics.py
@@ -9,9 +9,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import (
+    DEFAULT_BASE_PUSH,
     PARAM_API_URL,
     PARAM_APP_ID,
+    PARAM_BASE_PUSH,
     PARAM_ENABLE_EVENT_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
     PARAM_SELECTED_DEVICES,
     PARAM_WEBHOOK_ID,
     PARAM_WEBHOOK_URL,
@@ -29,10 +32,32 @@ async def async_get_config_entry_diagnostics(
         PARAM_SELECTED_DEVICES, []
     )
 
-    coordinator = entry.runtime_data.coordinator if entry.runtime_data else None
+    runtime = entry.runtime_data
+    coordinator = runtime.coordinator if runtime is not None else None
     last_update_success = (
         coordinator.last_update_success if coordinator is not None else None
     )
+
+    last_received = (
+        runtime.push_last_received_at.isoformat()
+        if runtime is not None and runtime.push_last_received_at is not None
+        else None
+    )
+
+    event_push = {
+        "enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
+        "webhook_url_configured": bool(webhook_url),
+        "event_push_types": list(entry.options.get(PARAM_EVENT_PUSH_TYPES, [])),
+        "base_push": entry.options.get(PARAM_BASE_PUSH, DEFAULT_BASE_PUSH),
+        "selected_devices_count": len(selected),
+        "recent_msg_type_counts": (
+            dict(runtime.push_msg_type_counts) if runtime is not None else {}
+        ),
+        "last_msg_type": (
+            runtime.push_last_msg_type if runtime is not None else None
+        ),
+        "last_received_at": last_received,
+    }
 
     return {
         "app_id": f"{app_id[:4]}…" if len(app_id) > 4 else app_id,
@@ -43,4 +68,5 @@ async def async_get_config_entry_diagnostics(
         "webhook_url_configured": bool(webhook_url),
         "last_update_success": last_update_success,
         "pyimouapi_version": version("pyimouapi"),
+        "event_push": event_push,
     }

--- a/custom_components/imou_life/event_push.py
+++ b/custom_components/imou_life/event_push.py
@@ -14,11 +14,11 @@ from .const import (
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
     PARAM_NOTIFY_SERVICES,
-    PARAM_SELECTED_DEVICES,
     PARAM_WEBHOOK_ID,
     PARAM_WEBHOOK_URL,
     event_push_types_to_callback_flags,
 )
+from .helpers import get_selected_device_ids
 from .repairs import (
     async_create_event_push_callback_failed_issue,
     async_create_event_push_no_url_issue,
@@ -44,9 +44,7 @@ async def async_setup_event_push(
     async_delete_event_push_issues(hass, entry)
     runtime.notify_services = []
     runtime.push_enabled = bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH))
-    runtime.selected_devices = entry.options.get(
-        PARAM_SELECTED_DEVICES
-    ) or entry.data.get(PARAM_SELECTED_DEVICES, [])
+    runtime.selected_devices = get_selected_device_ids(entry)
 
     webhook_id = entry.data.get(PARAM_WEBHOOK_ID, "")
     if not webhook_id:

--- a/custom_components/imou_life/event_push.py
+++ b/custom_components/imou_life/event_push.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from pyimouapi.openapi import ImouOpenApiClient
 
 from .const import (
-    PARAM_BASE_PUSH,
+    BASE_PUSH_ALWAYS,
     PARAM_ENABLE_EVENT_PUSH,
     PARAM_EVENT_PUSH_TYPES,
     PARAM_NOTIFY_SERVICES,
@@ -94,7 +94,6 @@ async def _async_set_message_callback(
     callback_flags = event_push_types_to_callback_flags(
         entry.options.get(PARAM_EVENT_PUSH_TYPES, [])
     )
-    base_push = entry.options.get(PARAM_BASE_PUSH, "2")
     if status == "on":
         if not callback_url:
             _LOGGER.error(
@@ -109,7 +108,7 @@ async def _async_set_message_callback(
                 status="on",
                 callback_url=callback_url,
                 callback_flag=callback_flags if callback_flags else None,
-                base_push=base_push,
+                base_push=BASE_PUSH_ALWAYS,
             )
             _LOGGER.info(
                 "Imou message callback set to %s (url=%s)",
@@ -124,7 +123,7 @@ async def _async_set_message_callback(
         try:
             await imou_client.async_set_message_callback(
                 status="off",
-                base_push=base_push,
+                base_push=BASE_PUSH_ALWAYS,
             )
             _LOGGER.info(
                 "Imou message callback set to %s (url=%s)",

--- a/custom_components/imou_life/event_push.py
+++ b/custom_components/imou_life/event_push.py
@@ -25,7 +25,11 @@ from .repairs import (
     async_delete_event_push_issues,
 )
 from .runtime_data import ImouRuntimeData
-from .webhook import async_register_imou_webhook, async_unregister_imou_webhook
+from .webhook import (
+    async_preload_webhook_strings,
+    async_register_imou_webhook,
+    async_unregister_imou_webhook,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +57,7 @@ async def async_setup_event_push(
         return webhook_id, ""
 
     generated_url = async_register_imou_webhook(hass, webhook_id)
+    await async_preload_webhook_strings(hass)
 
     if entry.options.get(PARAM_ENABLE_EVENT_PUSH):
         await _async_set_message_callback(hass, entry, imou_client, "on", generated_url)

--- a/custom_components/imou_life/helpers.py
+++ b/custom_components/imou_life/helpers.py
@@ -1,10 +1,26 @@
 """Shared helpers for Imou Life."""
 
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import translation
 from pyimouapi.device import ImouDeviceSummary
 
-from .const import DOMAIN
+from .const import DOMAIN, PARAM_SELECTED_DEVICES
+
+
+def get_selected_device_ids(entry: ConfigEntry) -> list[str] | None:
+    """Return selected device ids, or None when selection means all devices.
+
+    Empty list means poll/accept none. Missing key means no filter (all).
+    Options take precedence over data; an explicit empty list is preserved.
+    """
+    if PARAM_SELECTED_DEVICES in entry.options:
+        return list(entry.options[PARAM_SELECTED_DEVICES])
+    if PARAM_SELECTED_DEVICES in entry.data:
+        return list(entry.data[PARAM_SELECTED_DEVICES])
+    return None
 
 
 def format_device_label(hass: HomeAssistant, summary: ImouDeviceSummary) -> str:

--- a/custom_components/imou_life/helpers.py
+++ b/custom_components/imou_life/helpers.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import translation
 from pyimouapi.device import ImouDeviceSummary
 
-from .const import DOMAIN, PARAM_SELECTED_DEVICES
+from .const import DOMAIN, PARAM_SELECTED_DEVICES, imou_life_device_key_from_ids
 
 
 def get_selected_device_ids(entry: ConfigEntry) -> list[str] | None:
@@ -21,6 +22,22 @@ def get_selected_device_ids(entry: ConfigEntry) -> list[str] | None:
     if PARAM_SELECTED_DEVICES in entry.data:
         return list(entry.data[PARAM_SELECTED_DEVICES])
     return None
+
+
+def resolve_ha_device_name(
+    hass: HomeAssistant,
+    device_id: str | None,
+    channel_id: object | None = None,
+    product_id: str | None = None,
+) -> str | None:
+    """Return HA device display name for Imou ids, or None if not registered."""
+    key = imou_life_device_key_from_ids(device_id, channel_id, product_id)
+    if key is None:
+        return None
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, key)})
+    if device is None:
+        return None
+    return device.name_by_user or device.name
 
 
 def format_device_label(hass: HomeAssistant, summary: ImouDeviceSummary) -> str:

--- a/custom_components/imou_life/manifest.json
+++ b/custom_components/imou_life/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "pyimouapi==1.2.9"
+    "pyimouapi==1.3.1"
   ],
   "version": "1.3.0"
 }

--- a/custom_components/imou_life/manifest.json
+++ b/custom_components/imou_life/manifest.json
@@ -11,7 +11,7 @@
   "issue_tracker": "https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/issues",
   "quality_scale": "bronze",
   "requirements": [
-    "pyimouapi==1.3.1"
+    "pyimouapi==1.3.2"
   ],
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/custom_components/imou_life/runtime_data.py
+++ b/custom_components/imou_life/runtime_data.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .coordinator import ImouDataUpdateCoordinator
+
+_MAX_PUSH_MSG_TYPE_KEYS = 50
 
 
 @dataclass
@@ -17,3 +20,21 @@ class ImouRuntimeData:
     push_enabled: bool = False
     selected_devices: list[str] = field(default_factory=list)
     notify_services: list[str] = field(default_factory=list)
+    push_msg_type_counts: dict[str, int] = field(default_factory=dict)
+    push_last_msg_type: str | None = None
+    push_last_received_at: datetime | None = None
+
+    def record_push_msg(self, msg_type: str | None) -> None:
+        """Record an accepted push for diagnostics (in-memory only)."""
+        display = msg_type if msg_type is not None else "_unknown"
+        count_key = display
+        if (
+            count_key not in self.push_msg_type_counts
+            and len(self.push_msg_type_counts) >= _MAX_PUSH_MSG_TYPE_KEYS
+        ):
+            count_key = "_other"
+        self.push_msg_type_counts[count_key] = (
+            self.push_msg_type_counts.get(count_key, 0) + 1
+        )
+        self.push_last_msg_type = display
+        self.push_last_received_at = datetime.now(UTC)

--- a/custom_components/imou_life/runtime_data.py
+++ b/custom_components/imou_life/runtime_data.py
@@ -18,7 +18,8 @@ class ImouRuntimeData:
 
     coordinator: ImouDataUpdateCoordinator
     push_enabled: bool = False
-    selected_devices: list[str] = field(default_factory=list)
+    # None = all devices; [] = none; non-empty = allow-list
+    selected_devices: list[str] | None = None
     notify_services: list[str] = field(default_factory=list)
     push_msg_type_counts: dict[str, int] = field(default_factory=dict)
     push_last_msg_type: str | None = None

--- a/custom_components/imou_life/strings.json
+++ b/custom_components/imou_life/strings.json
@@ -50,7 +50,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "Current Webhook ID: {webhook_id}\n\nSuggested callback URL: {suggested_webhook_url}\n\nCurrent configured URL: {current_webhook_url}\n\nEnsure the 'Callback URL' field above matches the suggested URL; if left empty, the integration will use the auto-generated URL.",
+        "description": "Current Webhook ID: {webhook_id}\n\nSuggested callback URL: {suggested_webhook_url}\n\nCurrent configured URL: {current_webhook_url}\n\nLeave Callback URL empty to use the suggested URL. If that address is not reachable from the internet, enter your real public webhook URL instead.",
         "data": {
           "update_interval": "Polling interval (seconds)",
           "download_snap_wait_time": "Snapshot wait time (seconds)",
@@ -87,7 +87,7 @@
     "webhook_placeholder": {
       "options": {
         "not_generated": "Not generated",
-        "not_set_use_suggested": "Not set — the suggested URL above will be used"
+        "not_set_use_suggested": "Not set — will use the suggested URL above"
       }
     },
     "event_push_type": {

--- a/custom_components/imou_life/strings.json
+++ b/custom_components/imou_life/strings.json
@@ -60,7 +60,6 @@
           "enable_event_push": "Enable event push",
           "webhook_url": "Callback URL",
           "event_push_types": "Event push types",
-          "base_push": "Sync to Imou mobile app",
           "notify_services": "Alarm notification services"
         },
         "data_description": {
@@ -69,10 +68,9 @@
           "live_resolution": "Camera live stream resolution. HD = high definition, SD = standard.",
           "live_protocol": "Video stream protocol. Usually https is fine.",
           "rotation_duration": "How long a single PTZ button press moves. Default 500ms.",
-          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS).",
+          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS). Messages are also synced to the Imou app.",
           "webhook_url": "The URL where Imou cloud sends alarm messages. Leave empty to auto-generate (requires HA external URL configured). To set manually, enter full URL like: https://yourdomain:8123/api/webhook/xxxxx",
           "event_push_types": "Select which message types to receive. alarm = device alarms (smoke/gas/human/motion etc.), deviceStatus = online/offline, iot = IoT device messages, numberstat = people counting, faceAnalysis = face detection.",
-          "base_push": "Whether to also push messages to the Imou APP. 'Push' = Imou APP also receives, 'No push' = HA only.",
           "notify_services": "Where to send alarm notifications. Enter HA action names, separate with commas.\nExample: qiyewechat.send → WeChat Work\nExample: notify.mobile_app_xxx → HA APP push\nBoth: qiyewechat.send,notify.mobile_app_xxx\nLeave empty to skip (alarm events still fire for automations)."
         }
       },
@@ -99,12 +97,6 @@
         "iot": "IoT device messages",
         "numberstat": "People counting",
         "face_analysis": "Face analysis"
-      }
-    },
-    "base_push": {
-      "options": {
-        "1": "Push to Imou app",
-        "2": "Home Assistant only"
       }
     },
     "device_status": {

--- a/custom_components/imou_life/translations/en.json
+++ b/custom_components/imou_life/translations/en.json
@@ -50,7 +50,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "Current Webhook ID: {webhook_id}\n\nSuggested callback URL: {suggested_webhook_url}\n\nCurrent configured URL: {current_webhook_url}\n\nEnsure the 'Callback URL' field above matches the suggested URL; if left empty, the integration will use the auto-generated URL.",
+        "description": "Current Webhook ID: {webhook_id}\n\nSuggested callback URL: {suggested_webhook_url}\n\nCurrent configured URL: {current_webhook_url}\n\nLeave Callback URL empty to use the suggested URL. If that address is not reachable from the internet, enter your real public webhook URL instead.",
         "data": {
           "update_interval": "Polling interval (seconds)",
           "download_snap_wait_time": "Snapshot wait time (seconds)",
@@ -87,7 +87,7 @@
     "webhook_placeholder": {
       "options": {
         "not_generated": "Not generated",
-        "not_set_use_suggested": "Not set — the suggested URL above will be used"
+        "not_set_use_suggested": "Not set — will use the suggested URL above"
       }
     },
     "event_push_type": {

--- a/custom_components/imou_life/translations/en.json
+++ b/custom_components/imou_life/translations/en.json
@@ -60,7 +60,6 @@
           "enable_event_push": "Enable event push",
           "webhook_url": "Callback URL",
           "event_push_types": "Event push types",
-          "base_push": "Sync to Imou mobile app",
           "notify_services": "Alarm notification services"
         },
         "data_description": {
@@ -69,10 +68,9 @@
           "live_resolution": "Camera live stream resolution. HD = high definition, SD = standard.",
           "live_protocol": "Video stream protocol. Usually https is fine.",
           "rotation_duration": "How long a single PTZ button press moves. Default 500ms.",
-          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS).",
+          "enable_event_push": "When enabled, Imou cloud will push alarm events to your HA in real time. Requires a publicly accessible URL (domain/DDNS). Messages are also synced to the Imou app.",
           "webhook_url": "The URL where Imou cloud sends alarm messages. Leave empty to auto-generate (requires HA external URL configured). To set manually, enter full URL like: https://yourdomain:8123/api/webhook/xxxxx",
           "event_push_types": "Select which message types to receive. alarm = device alarms (smoke/gas/human/motion etc.), deviceStatus = online/offline, iot = IoT device messages, numberstat = people counting, faceAnalysis = face detection.",
-          "base_push": "Whether to also push messages to the Imou APP. 'Push' = Imou APP also receives, 'No push' = HA only.",
           "notify_services": "Where to send alarm notifications. Enter HA action names, separate with commas.\nExample: qiyewechat.send → WeChat Work\nExample: notify.mobile_app_xxx → HA APP push\nBoth: qiyewechat.send,notify.mobile_app_xxx\nLeave empty to skip (alarm events still fire for automations)."
         }
       },
@@ -99,12 +97,6 @@
         "iot": "IoT device messages",
         "numberstat": "People counting",
         "face_analysis": "Face analysis"
-      }
-    },
-    "base_push": {
-      "options": {
-        "1": "Push to Imou app",
-        "2": "Home Assistant only"
       }
     },
     "device_status": {

--- a/custom_components/imou_life/translations/zh-Hans.json
+++ b/custom_components/imou_life/translations/zh-Hans.json
@@ -50,7 +50,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "当前真实 Webhook ID：{webhook_id}\n\n建议回调地址：{suggested_webhook_url}\n\n当前填写地址：{current_webhook_url}\n\n请确保上面的『消息回调地址』填写为建议回调地址；如果留空，则使用集成自动生成的地址。",
+        "description": "当前 Webhook ID：{webhook_id}\n\n建议回调地址：{suggested_webhook_url}\n\n当前填写地址：{current_webhook_url}\n\n『消息回调地址』留空则使用上方建议地址。若该地址外网无法访问，请改为填写实际可用的完整公网 URL。",
         "data": {
           "update_interval": "自动刷新间隔（秒）",
           "download_snap_wait_time": "抓图等待时间（秒）",
@@ -87,7 +87,7 @@
     "webhook_placeholder": {
       "options": {
         "not_generated": "未生成",
-        "not_set_use_suggested": "未填写，将使用上方建议地址/自动生成地址"
+        "not_set_use_suggested": "未填写 — 将使用上方建议地址"
       }
     },
     "event_push_type": {

--- a/custom_components/imou_life/translations/zh-Hans.json
+++ b/custom_components/imou_life/translations/zh-Hans.json
@@ -60,7 +60,6 @@
           "enable_event_push": "启用消息推送",
           "webhook_url": "消息回调地址",
           "event_push_types": "推送消息类型",
-          "base_push": "乐橙APP消息同步",
           "notify_services": "报警通知服务"
         },
         "data_description": {
@@ -69,10 +68,9 @@
           "live_resolution": "摄像头直播的分辨率，HD=高清，SD=标清",
           "live_protocol": "视频流协议，一般用https即可",
           "rotation_duration": "按一次云台方向按钮转多久，默认500毫秒",
-          "enable_event_push": "打开后，乐橙云会把设备报警消息实时推送到你的HA。需要HA有公网可访问的地址（域名/DDNS均可）",
+          "enable_event_push": "打开后，乐橙云会把设备报警消息实时推送到你的HA，并同步推送到乐橙APP。需要HA有公网可访问的地址（域名/DDNS均可）",
           "webhook_url": "乐橙云把报警消息推到哪个地址。留空会自动生成（前提是HA已配置外部URL）。如果自动生成不对，手动填完整URL，格式如：https://你的域名:8123/api/webhook/xxxxx",
           "event_push_types": "选择要接收哪些类型的消息。alarm=设备报警（烟感/燃气/人形/动检等），deviceStatus=设备上下线，iot=物联网设备消息，numberstat=客流统计，faceAnalysis=人脸智能分析",
-          "base_push": "是否同时把消息推送给乐橙APP。选\"推送\"=乐橙APP也会收到，选\"不推送\"=只推给HA",
           "notify_services": "收到报警后自动发通知到哪里。填HA的动作名称，多个用英文逗号分隔。\n\n查找方法：HA → 开发者工具 → 动作 → 搜索你要用的通知服务\n\n例如：qiyewechat.send  →  企业微信通知\n例如：notify.mobile_app_xxx  →  HA APP弹窗通知\n同时推两个：qiyewechat.send,notify.mobile_app_xxx\n\n留空则不自动发通知（但报警事件仍会触发，可在自动化中使用）"
         }
       },
@@ -99,12 +97,6 @@
         "iot": "物联网设备消息",
         "numberstat": "客流统计",
         "face_analysis": "人脸智能分析"
-      }
-    },
-    "base_push": {
-      "options": {
-        "1": "推送",
-        "2": "不推送"
       }
     },
     "device_status": {

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -14,6 +14,7 @@ from homeassistant.components import webhook
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, EVENT_IMOU_ALARM, EVENT_IMOU_EVENT, PARAM_WEBHOOK_ID
+from .helpers import resolve_ha_device_name
 from .runtime_data import ImouRuntimeData
 
 _LOGGER = logging.getLogger(__name__)
@@ -211,7 +212,10 @@ async def _async_build_notification_message(
     unknown_device = notif.get("unknown_device", "Unknown device")
     unknown_alarm = notif.get("unknown_alarm", "Alarm")
     device_name = (
-        event_data.get("name") or event_data.get("device_id") or unknown_device
+        event_data.get("device_name")
+        or event_data.get("name")
+        or event_data.get("device_id")
+        or unknown_device
     )
     alarm_type = alarm_types.get(msg_type, msg_type or unknown_alarm)
 
@@ -334,6 +338,13 @@ async def async_handle_imou_webhook(
             selected_devices,
         )
         return web.Response(status=200, text="ok")
+
+    event_data["device_name"] = resolve_ha_device_name(
+        hass,
+        event_data.get("device_id"),
+        channel_id=event_data.get("channel_id"),
+        product_id=event_data.get("product_id"),
+    )
 
     runtime.record_push_msg(msg_type)
 

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -35,6 +35,7 @@ _NON_ALARM_MSG_TYPES = frozenset(
         "iotProperty",
         "iotAction",
         "numberstat",
+        "electricity",
         # privacy mask (#66)
         "openCamera",
         "closeCamera",
@@ -124,9 +125,6 @@ def _normalize_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
     content = payload.get("content")
     output_data = None
     if isinstance(content, dict):
-        iot_event = content.get("event")
-        if msg_type == "iotEvent" and iot_event is not None and iot_event != "":
-            msg_type = str(iot_event)
         output_data = content.get("outputData")
         if channel_id is None:
             monitor = content.get("monitor")
@@ -150,6 +148,57 @@ def _normalize_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "raw": payload,
     }
     return event
+
+
+def _is_digit_str(value: Any) -> bool:
+    return isinstance(value, str) and value.isdigit()
+
+
+def _lookup_key_for_event_resolve(
+    msg_type: str | None, raw: dict[str, Any]
+) -> str | None:
+    """Return the product-model event ref to resolve, or None to skip."""
+    if _is_digit_str(msg_type):
+        return msg_type
+    if msg_type == "iotEvent":
+        content = raw.get("content")
+        if isinstance(content, dict):
+            event_ref = content.get("event")
+            if event_ref is None or event_ref == "":
+                return None
+            key = str(event_ref)
+            if key.isdigit():
+                return key
+    return None
+
+
+async def _async_apply_event_identifier(
+    runtime: ImouRuntimeData, event_data: dict[str, Any]
+) -> None:
+    """Rewrite outbound msg_type to identifier when resolvable."""
+    product_id = event_data.get("product_id")
+    raw = event_data.get("raw")
+    if not product_id or not isinstance(raw, dict):
+        return
+    lookup_key = _lookup_key_for_event_resolve(event_data.get("msg_type"), raw)
+    if not lookup_key:
+        return
+    try:
+        delegate = runtime.coordinator.device_manager.delegate
+        identifier = await delegate.async_resolve_event_identifier(
+            product_id, lookup_key
+        )
+    except Exception:
+        _LOGGER.warning(
+            "Failed to resolve event identifier for product_id=%s key=%s",
+            product_id,
+            lookup_key,
+            exc_info=True,
+        )
+        return
+    if identifier:
+        event_data["msg_type"] = identifier
+        event_data["msg_type_name"] = identifier
 
 
 async def _async_build_notification_message(
@@ -286,11 +335,14 @@ async def async_handle_imou_webhook(
 
     runtime.record_push_msg(msg_type)
 
+    # Classify on original top-level msgType before outbound identifier rewrite.
+    is_alarm = _is_alarm_msg_type(msg_type)
+    await _async_apply_event_identifier(runtime, event_data)
+
     # Always fire the generic event
     hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)
 
     # Fire alarm-specific event + send notifications for security alarms
-    is_alarm = _is_alarm_msg_type(msg_type)
     if is_alarm:
         hass.bus.async_fire(EVENT_IMOU_ALARM, event_data)
 

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -261,6 +261,8 @@ async def async_handle_imou_webhook(
         )
         return web.Response(status=200, text="ok")
 
+    runtime.record_push_msg(msg_type)
+
     # Always fire the generic event
     hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)
 

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -20,19 +20,58 @@ _LOGGER = logging.getLogger(__name__)
 
 _WEBHOOK_STRINGS_DIR = Path(__file__).parent / "webhook_strings"
 
-# Message types that are NOT alarm events (status / iot / stats)
-_NON_ALARM_TYPES = frozenset(
+# Status / ops types that must NOT fire imou_life_alarm or notify.
+# Official Imou "Device alarm" list also includes privacy-mask and lifecycle
+# types; we subtract those here. See:
+# https://open.imoulife.com/book/en/push/alarm.html
+_NON_ALARM_MSG_TYPES = frozenset(
     {
+        # deviceStatus
         "online",
         "offline",
         "close",
         "changeDevName",
+        # iot / stats
         "iotEvent",
         "iotProperty",
         "iotAction",
         "numberstat",
+        # privacy mask (#66)
+        "openCamera",
+        "closeCamera",
+        # light / siren state
+        "whiteLightOn",
+        "whiteLightOff",
+        "sirenOn",
+        "sirenOff",
+        # sleep
+        "sleep",
+        # bind / share / auth / transfer
+        "bindDevice",
+        "unbindDevice",
+        "deviceShare",
+        "deviceShareCancel",
+        "deviceAuthorize",
+        "deviceAuthorizationChanged",
+        "transferDeviceFrom",
+        "transferDeviceTo",
+        "deviceDeletedSharedCancel",
+        # upgrade / storage ops
+        "UpgradeSuccess",
+        "upgradeFail",
+        "apUpgradeSuccess",
+        "apUpgradeFail",
+        "storageRecoverOk",
+        "storageRecoverFail",
+        "storageEmpty",
+        "storageAbnormal",
     }
 )
+
+
+def _is_alarm_msg_type(msg_type: str | None) -> bool:
+    """Return True if this push should fire imou_life_alarm / notify."""
+    return msg_type is not None and msg_type not in _NON_ALARM_MSG_TYPES
 
 
 def _webhook_strings_filename(language: str) -> str:
@@ -225,8 +264,8 @@ async def async_handle_imou_webhook(
     # Always fire the generic event
     hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)
 
-    # Fire alarm-specific event + send notifications for non-status messages
-    is_alarm = msg_type not in _NON_ALARM_TYPES
+    # Fire alarm-specific event + send notifications for security alarms
+    is_alarm = _is_alarm_msg_type(msg_type)
     if is_alarm:
         hass.bus.async_fire(EVENT_IMOU_ALARM, event_data)
 

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -323,9 +323,11 @@ async def async_handle_imou_webhook(
         _LOGGER.debug("Push is disabled, ignoring event")
         return web.Response(status=200, text="ok")
 
-    # Filter: only process events from selected devices (if device selection is active)
+    # Filter: None = all devices; [] = none; otherwise allow-list
     selected_devices = runtime.selected_devices
-    if selected_devices and device_id and device_id not in selected_devices:
+    if selected_devices is not None and (
+        not device_id or device_id not in selected_devices
+    ):
         _LOGGER.debug(
             "Ignoring push from unselected device %s (selected: %s)",
             device_id,

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -79,15 +79,27 @@ def _webhook_strings_filename(language: str) -> str:
 
 @lru_cache(maxsize=4)
 def _load_webhook_strings_file(filename: str) -> dict[str, Any]:
+    """Load a webhook strings JSON file (blocking; call via executor)."""
     path = _WEBHOOK_STRINGS_DIR / filename
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def _get_webhook_strings(
+_WEBHOOK_STRING_FILES = ("en.json", "zh-Hans.json")
+
+
+async def async_preload_webhook_strings(hass: HomeAssistant) -> None:
+    """Warm webhook string cache off the event loop."""
+    for filename in _WEBHOOK_STRING_FILES:
+        await hass.async_add_executor_job(_load_webhook_strings_file, filename)
+
+
+async def _async_get_webhook_strings(
+    hass: HomeAssistant,
     language: str,
 ) -> tuple[dict[str, str], dict[str, str]]:
     """Load webhook notification templates and alarm type labels."""
-    data = _load_webhook_strings_file(_webhook_strings_filename(language))
+    filename = _webhook_strings_filename(language)
+    data = await hass.async_add_executor_job(_load_webhook_strings_file, filename)
     notification = data.get("notification", {})
     alarm_types = data.get("alarm_types", {})
     return notification, alarm_types
@@ -144,7 +156,7 @@ async def _async_build_notification_message(
     hass: HomeAssistant, event_data: dict[str, Any]
 ) -> tuple[str, str]:
     """Build a notification title and message from an event payload."""
-    notif, alarm_types = _get_webhook_strings(hass.config.language)
+    notif, alarm_types = await _async_get_webhook_strings(hass, hass.config.language)
 
     msg_type = event_data.get("msg_type")
     unknown_device = notif.get("unknown_device", "Unknown device")

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -300,6 +300,26 @@ def _get_runtime_data_for_webhook(
     return None
 
 
+async def _async_dispatch_imou_push(
+    hass: HomeAssistant,
+    runtime: ImouRuntimeData,
+    event_data: dict[str, Any],
+    *,
+    is_alarm: bool,
+) -> None:
+    """Resolve identifiers, fire events, and notify after webhook ACK."""
+    try:
+        await _async_apply_event_identifier(runtime, event_data)
+        hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)
+        if is_alarm:
+            hass.bus.async_fire(EVENT_IMOU_ALARM, event_data)
+            notify_services = runtime.notify_services
+            if notify_services:
+                await _async_send_notifications(hass, event_data, notify_services)
+    except Exception:
+        _LOGGER.exception("Failed while processing accepted Imou webhook push")
+
+
 async def async_handle_imou_webhook(
     hass: HomeAssistant,
     webhook_id: str,
@@ -350,21 +370,12 @@ async def async_handle_imou_webhook(
 
     # Classify on original top-level msgType before outbound identifier rewrite.
     is_alarm = _is_alarm_msg_type(msg_type)
-    await _async_apply_event_identifier(runtime, event_data)
 
-    # Always fire the generic event
-    hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)
-
-    # Fire alarm-specific event + send notifications for security alarms
-    if is_alarm:
-        hass.bus.async_fire(EVENT_IMOU_ALARM, event_data)
-
-    # Send notifications if configured
-    notify_services = runtime.notify_services
-    if is_alarm and notify_services:
-        await _async_send_notifications(hass, event_data, notify_services)
-
-    # Imou explicitly requires HTTP 200, otherwise it may stop pushing messages.
+    # ACK first so Imou does not stop pushing while we resolve/notify.
+    hass.async_create_task(
+        _async_dispatch_imou_push(hass, runtime, event_data, is_alarm=is_alarm),
+        name=f"{DOMAIN}_webhook_dispatch_{webhook_id}",
+    )
     return web.Response(status=200, text="ok")
 
 

--- a/custom_components/imou_life/webhook.py
+++ b/custom_components/imou_life/webhook.py
@@ -31,19 +31,16 @@ _NON_ALARM_MSG_TYPES = frozenset(
         "offline",
         "close",
         "changeDevName",
-        # iot / stats
-        "iotEvent",
+        # iot property/action & stats (iotEvent is an alarm)
         "iotProperty",
         "iotAction",
         "numberstat",
         # privacy mask (#66)
         "openCamera",
         "closeCamera",
-        # light / siren state
+        # light state (sirenOn/sirenOff are alarms)
         "whiteLightOn",
         "whiteLightOff",
-        "sirenOn",
-        "sirenOff",
         # sleep
         "sleep",
         # bind / share / auth / transfer
@@ -112,6 +109,18 @@ def _normalize_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
         or payload.get("channels")
     )
     msg_type = payload.get("msgType")
+    content = payload.get("content")
+    output_data = None
+    if isinstance(content, dict):
+        iot_event = content.get("event")
+        if msg_type == "iotEvent" and iot_event is not None and iot_event != "":
+            msg_type = str(iot_event)
+        output_data = content.get("outputData")
+        if channel_id is None:
+            monitor = content.get("monitor")
+            if isinstance(monitor, dict) and "channel" in monitor:
+                channel_id = monitor.get("channel")
+
     raw_time = payload.get("time") or payload.get("localTime") or payload.get("utcTime")
 
     event = {
@@ -119,11 +128,13 @@ def _normalize_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
         "msg_type_name": msg_type,
         "device_id": device_id,
         "channel_id": channel_id,
+        "product_id": payload.get("pid"),
         "time": raw_time,
         "name": payload.get("cname") or payload.get("dname"),
         "alarm_id": payload.get("id") or payload.get("alarmId"),
         "token": payload.get("token"),
         "desc": payload.get("desc"),
+        "outputData": output_data,
         "raw": payload,
     }
     return event

--- a/docs/superpowers/plans/2026-07-21-imou-webhook-alarm-classification.md
+++ b/docs/superpowers/plans/2026-07-21-imou-webhook-alarm-classification.md
@@ -1,0 +1,776 @@
+# Webhook 报警分类与推送可观测性 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 #66：将 `openCamera`/`closeCamera` 等非安防推送排除出 `imou_life_alarm`，并用 runtime 计数 + diagnostics 支撑动检/人形漏推排查。
+
+**Architecture:** 混合判定（默认报警 − `NON_ALARM_MSG_TYPES` 黑名单）；webhook 在通过过滤后更新 `ImouRuntimeData` 内存计数；diagnostics 输出本地 push 配置与近期 `msgType` 统计。不轮询、不调用 `getMessageCallback`。
+
+**Tech Stack:** Home Assistant custom integration (`imou_life`), pytest, pytest-homeassistant-custom-component, ruff, uv
+
+**Spec:** `docs/superpowers/specs/2026-07-21-imou-webhook-alarm-classification-design.md`
+
+## Global Constraints
+
+- 仓库：`Imou-Home-Assistant` only（不改 pyimouapi / HA core）
+- 事件名与 payload 字段不变：`imou_life_event` / `imou_life_alarm`
+- Webhook 始终 HTTP 200
+- 计数仅内存、不持久化、不做实体
+- 每个 Task 结束后：相关 pytest 通过；Task 末 `git commit`（勿提交无关 sensor/1.3.1 脏文件）
+- 验证命令：`uv run pytest tests/test_webhook.py tests/test_diagnostics.py -q --timeout=30`；最终 `script/lint-check` + `script/test`
+
+## 文件影响总览
+
+| 文件 | 职责 |
+|------|------|
+| `custom_components/imou_life/webhook.py` | `NON_ALARM_MSG_TYPES`、`_is_alarm_msg_type`、handler 判定与计数调用 |
+| `custom_components/imou_life/runtime_data.py` | push 计数字段 + `record_push_msg` |
+| `custom_components/imou_life/diagnostics.py` | `event_push` 诊断块 |
+| `tests/test_webhook.py` | 分类、notify、计数测试 |
+| `tests/test_diagnostics.py` | diagnostics 字段测试 |
+| `README.md` | Troubleshooting Event push |
+| `CHANGELOG.md` | Fixed 条目（写入当前未发布版本节，现为 `[1.3.1]`） |
+
+---
+
+### Task 1: 报警分类辅助函数（TDD）
+
+**Files:**
+- Modify: `custom_components/imou_life/webhook.py`
+- Test: `tests/test_webhook.py`
+
+**Interfaces:**
+- Produces: `_is_alarm_msg_type(msg_type: str | None) -> bool`
+- Produces: `NON_ALARM_MSG_TYPES: frozenset[str]`（可保持模块级私有名 `_NON_ALARM_MSG_TYPES`，但测试从 `webhook` 导入 `_is_alarm_msg_type`）
+
+- [ ] **Step 1: Write the failing tests**
+
+在 `tests/test_webhook.py` 追加：
+
+```python
+from custom_components.imou_life.webhook import _is_alarm_msg_type
+
+
+@pytest.mark.parametrize(
+    ("msg_type", "expected"),
+    [
+        ("closeCamera", False),
+        ("openCamera", False),
+        ("online", False),
+        ("iotProperty", False),
+        ("whiteLightOn", False),
+        ("bindDevice", False),
+        ("videoMotion", True),
+        ("human", True),
+        ("abAlarmSound", True),
+        ("mobileDetect", True),
+        ("alarmLocal", True),
+        ("totallyUnknownType", True),
+        (None, False),
+    ],
+)
+def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
+    """Hybrid classification: denylist non-alarms; unknown types are alarms."""
+    assert _is_alarm_msg_type(msg_type) is expected
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/open/projects/Imou-Home-Assistant
+uv run pytest tests/test_webhook.py::test_is_alarm_msg_type -v --timeout=30
+```
+
+Expected: `ImportError` 或 `AttributeError`（`_is_alarm_msg_type` 不存在）
+
+- [ ] **Step 3: Implement classification in `webhook.py`**
+
+替换原 `_NON_ALARM_TYPES`（约 L23–35）为：
+
+```python
+# Status / ops types that must NOT fire imou_life_alarm or notify.
+# Official Imou "Device alarm" list also includes privacy-mask and lifecycle
+# types; we subtract those here. See:
+# https://open.imoulife.com/book/en/push/alarm.html
+_NON_ALARM_MSG_TYPES = frozenset(
+    {
+        # deviceStatus
+        "online",
+        "offline",
+        "close",
+        "changeDevName",
+        # iot / stats
+        "iotEvent",
+        "iotProperty",
+        "iotAction",
+        "numberstat",
+        # privacy mask (#66)
+        "openCamera",
+        "closeCamera",
+        # light / siren state
+        "whiteLightOn",
+        "whiteLightOff",
+        "sirenOn",
+        "sirenOff",
+        # sleep
+        "sleep",
+        # bind / share / auth / transfer
+        "bindDevice",
+        "unbindDevice",
+        "deviceShare",
+        "deviceShareCancel",
+        "deviceAuthorize",
+        "deviceAuthorizationChanged",
+        "transferDeviceFrom",
+        "transferDeviceTo",
+        "deviceDeletedSharedCancel",
+        # upgrade / storage ops
+        "UpgradeSuccess",
+        "upgradeFail",
+        "apUpgradeSuccess",
+        "apUpgradeFail",
+        "storageRecoverOk",
+        "storageRecoverFail",
+        "storageEmpty",
+        "storageAbnormal",
+    }
+)
+
+
+def _is_alarm_msg_type(msg_type: str | None) -> bool:
+    """Return True if this push should fire imou_life_alarm / notify."""
+    return msg_type is not None and msg_type not in _NON_ALARM_MSG_TYPES
+```
+
+将 handler 中：
+
+```python
+is_alarm = msg_type not in _NON_ALARM_TYPES
+```
+
+改为：
+
+```python
+is_alarm = _is_alarm_msg_type(msg_type)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/test_webhook.py::test_is_alarm_msg_type tests/test_webhook.py::test_webhook_iot_property_is_not_alarm -v --timeout=30
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/imou_life/webhook.py tests/test_webhook.py
+git commit -m "$(cat <<'EOF'
+fix: classify privacy-mask pushes as non-alarm events
+
+Exclude openCamera/closeCamera and other status/ops msgTypes from
+imou_life_alarm so automations and notify are not misfired (#66).
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Webhook 集成行为（closeCamera / 真报警 / notify）
+
+**Files:**
+- Modify: `tests/test_webhook.py`
+- Modify: `custom_components/imou_life/webhook.py`（仅当 Task 1 未改全 handler 时）
+
+**Interfaces:**
+- Consumes: `_is_alarm_msg_type`, `async_handle_imou_webhook`, `setup_imou_runtime`
+
+- [ ] **Step 1: Write the failing tests**
+
+在 `tests/test_webhook.py` 追加：
+
+```python
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["closeCamera", "openCamera"])
+async def test_webhook_privacy_mask_is_not_alarm(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Privacy mask open/close fires generic event only."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["device_1"],
+        notify_services=["notify.test"],
+    )
+    hass.services.async_register("notify", "test", lambda call: None)
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": msg_type,
+                "did": "device_1",
+                "cid": 0,
+                "dname": "Cam",
+                "time": 1783528060,
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert generic_events[0].data["msg_type"] == msg_type
+    assert alarm_events == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["videoMotion", "human", "abAlarmSound"])
+async def test_webhook_security_alarms_fire_alarm_event(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Security alarm msgTypes fire both generic and alarm events."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": msg_type, "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 1
+    assert alarm_events[0].data["msg_type"] == msg_type
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_missing_msg_type_is_not_alarm(
+    hass: HomeAssistant,
+) -> None:
+    """Payload without msgType still fires generic event, not alarm."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert alarm_events == []
+```
+
+若 `hass.services.async_register("notify", "test", ...)` 在当前 HA 测试环境签名不兼容，改为只断言 `alarm_events == []`（notify 仅在 `is_alarm` 时调用，无 alarm 即无 notify）。优先保留无 alarm 断言即可满足 #66。
+
+- [ ] **Step 2: Run tests**
+
+```bash
+uv run pytest tests/test_webhook.py::test_webhook_privacy_mask_is_not_alarm \
+  tests/test_webhook.py::test_webhook_security_alarms_fire_alarm_event \
+  tests/test_webhook.py::test_webhook_missing_msg_type_is_not_alarm -v --timeout=30
+```
+
+Expected: PASS（Task 1 已改 handler）；若 FAIL，检查 handler 是否仍用旧 `_NON_ALARM_TYPES` 名称。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_webhook.py
+git commit -m "$(cat <<'EOF'
+test: cover webhook alarm vs privacy-mask event split
+
+EOF
+)"
+```
+
+---
+
+### Task 3: Runtime 推送计数
+
+**Files:**
+- Modify: `custom_components/imou_life/runtime_data.py`
+- Modify: `custom_components/imou_life/webhook.py`
+- Test: `tests/test_webhook.py`
+
+**Interfaces:**
+- Produces on `ImouRuntimeData`:
+  - `push_msg_type_counts: dict[str, int]`
+  - `push_last_msg_type: str | None`
+  - `push_last_received_at: datetime | None`
+  - `record_push_msg(self, msg_type: str | None) -> None`
+- Consumes in webhook: after device filter passes, before/after `async_fire(EVENT_IMOU_EVENT)` 调用 `runtime.record_push_msg(msg_type)`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_records_msg_type_counts(hass: HomeAssistant) -> None:
+    """Accepted pushes increment runtime msgType counters."""
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "abAlarmSound", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts["closeCamera"] == 2
+    assert runtime.push_msg_type_counts["abAlarmSound"] == 1
+    assert runtime.push_last_msg_type == "abAlarmSound"
+    assert runtime.push_last_received_at is not None
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_filtered_device_does_not_count(
+    hass: HomeAssistant,
+) -> None:
+    """Unselected devices do not update push counters."""
+    runtime = setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["selected_device"],
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "alarmLocal", "deviceId": "other_device"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts == {}
+    assert runtime.push_last_msg_type is None
+```
+
+另加纯单元测试（可不依赖 HA fixture）：
+
+```python
+from datetime import UTC, datetime
+
+from custom_components.imou_life.runtime_data import ImouRuntimeData
+
+
+def test_record_push_msg_caps_distinct_keys() -> None:
+    """More than 50 distinct msgTypes fold into _other."""
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    for i in range(50):
+        runtime.record_push_msg(f"type_{i}")
+    assert len(runtime.push_msg_type_counts) == 50
+    runtime.record_push_msg("type_extra")
+    assert runtime.push_msg_type_counts["_other"] == 1
+    assert "type_extra" not in runtime.push_msg_type_counts
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/test_webhook.py::test_webhook_records_msg_type_counts \
+  tests/test_webhook.py::test_webhook_filtered_device_does_not_count \
+  tests/test_webhook.py::test_record_push_msg_caps_distinct_keys -v --timeout=30
+```
+
+Expected: FAIL（缺字段 / `record_push_msg`）
+
+- [ ] **Step 3: Implement `runtime_data.py`**
+
+```python
+"""Runtime data stored on Imou config entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .coordinator import ImouDataUpdateCoordinator
+
+_MAX_PUSH_MSG_TYPE_KEYS = 50
+
+
+@dataclass
+class ImouRuntimeData:
+    """Data attached to a config entry at runtime."""
+
+    coordinator: ImouDataUpdateCoordinator
+    push_enabled: bool = False
+    selected_devices: list[str] = field(default_factory=list)
+    notify_services: list[str] = field(default_factory=list)
+    push_msg_type_counts: dict[str, int] = field(default_factory=dict)
+    push_last_msg_type: str | None = None
+    push_last_received_at: datetime | None = None
+
+    def record_push_msg(self, msg_type: str | None) -> None:
+        """Record an accepted push for diagnostics (in-memory only)."""
+        key = msg_type if msg_type is not None else "_unknown"
+        if (
+            key not in self.push_msg_type_counts
+            and len(self.push_msg_type_counts) >= _MAX_PUSH_MSG_TYPE_KEYS
+        ):
+            key = "_other"
+        self.push_msg_type_counts[key] = self.push_msg_type_counts.get(key, 0) + 1
+        self.push_last_msg_type = msg_type if msg_type is not None else "_unknown"
+        self.push_last_received_at = datetime.now(UTC)
+```
+
+注意：封顶后 `push_last_msg_type` 仍应反映真实类型还是 `_other`？按可观测性意图，**last 用真实 `msg_type`（或 `_unknown`）**，计数键在封顶时用 `_other`：
+
+```python
+    def record_push_msg(self, msg_type: str | None) -> None:
+        """Record an accepted push for diagnostics (in-memory only)."""
+        display = msg_type if msg_type is not None else "_unknown"
+        count_key = display
+        if (
+            count_key not in self.push_msg_type_counts
+            and len(self.push_msg_type_counts) >= _MAX_PUSH_MSG_TYPE_KEYS
+        ):
+            count_key = "_other"
+        self.push_msg_type_counts[count_key] = (
+            self.push_msg_type_counts.get(count_key, 0) + 1
+        )
+        self.push_last_msg_type = display
+        self.push_last_received_at = datetime.now(UTC)
+```
+
+同步调整 `test_record_push_msg_caps_distinct_keys`：`push_last_msg_type == "type_extra"` 且 `counts["_other"] == 1`。
+
+- [ ] **Step 4: Wire webhook**
+
+在 `async_handle_imou_webhook` 中，设备过滤通过之后、`hass.bus.async_fire(EVENT_IMOU_EVENT, event_data)` 之前插入：
+
+```python
+    runtime.record_push_msg(msg_type)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/test_webhook.py -q --timeout=30
+```
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/imou_life/runtime_data.py \
+  custom_components/imou_life/webhook.py tests/test_webhook.py
+git commit -m "$(cat <<'EOF'
+feat: track webhook msgType counts on runtime data
+
+Expose in-memory counters for diagnostics so missing motion/human
+pushes can be distinguished from misclassification (#66).
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Diagnostics `event_push` 块
+
+**Files:**
+- Modify: `custom_components/imou_life/diagnostics.py`
+- Modify: `tests/test_diagnostics.py`
+
+**Interfaces:**
+- Consumes: `ImouRuntimeData.push_*`、`PARAM_EVENT_PUSH_TYPES`、`PARAM_BASE_PUSH`、`DEFAULT_BASE_PUSH`
+- Produces diagnostics key `event_push: dict[str, Any]`
+
+- [ ] **Step 1: Write the failing test**
+
+更新/扩展 `tests/test_diagnostics.py`：
+
+```python
+"""Tests for Imou Life diagnostics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from custom_components.imou_life.const import (
+    DOMAIN,
+    PARAM_BASE_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
+    PARAM_WEBHOOK_ID,
+)
+from custom_components.imou_life.diagnostics import async_get_config_entry_diagnostics
+from custom_components.imou_life.runtime_data import ImouRuntimeData
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from . import USER_INPUT
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_diagnostics_redacts_secrets(hass) -> None:
+    """Diagnostics must not expose App Secret."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**USER_INPUT, PARAM_WEBHOOK_ID: "abcd1234efgh5678"},
+        options={"enable_event_push": True},
+    )
+    entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    entry.runtime_data = ImouRuntimeData(coordinator=coordinator)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "app_secret" not in result
+    assert result["app_id"] == "test…"
+    assert result["webhook_id"] == "abcd1234…"
+    assert result["event_push_enabled"] is True
+    assert result["last_update_success"] is True
+    assert "pyimouapi_version" in result
+    assert result["event_push"]["enabled"] is True
+    assert result["event_push"]["recent_msg_type_counts"] == {}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_diagnostics_includes_push_msg_counts(hass) -> None:
+    """Diagnostics expose runtime push msgType counters."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**USER_INPUT, PARAM_WEBHOOK_ID: "abcd1234efgh5678"},
+        options={
+            "enable_event_push": True,
+            PARAM_EVENT_PUSH_TYPES: ["alarm", "device_status"],
+            PARAM_BASE_PUSH: "2",
+            "webhook_url": "https://example.com/hook",
+        },
+    )
+    entry.add_to_hass(hass)
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    runtime.record_push_msg("closeCamera")
+    runtime.record_push_msg("abAlarmSound")
+    entry.runtime_data = runtime
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    event_push = result["event_push"]
+
+    assert event_push["enabled"] is True
+    assert event_push["webhook_url_configured"] is True
+    assert event_push["event_push_types"] == ["alarm", "device_status"]
+    assert event_push["base_push"] == "2"
+    assert event_push["recent_msg_type_counts"] == {
+        "closeCamera": 1,
+        "abAlarmSound": 1,
+    }
+    assert event_push["last_msg_type"] == "abAlarmSound"
+    assert event_push["last_received_at"] is not None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_diagnostics.py -v --timeout=30
+```
+
+Expected: FAIL（缺 `event_push`）
+
+- [ ] **Step 3: Implement diagnostics**
+
+```python
+"""Diagnostics support for Imou Life."""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DEFAULT_BASE_PUSH,
+    PARAM_API_URL,
+    PARAM_APP_ID,
+    PARAM_BASE_PUSH,
+    PARAM_ENABLE_EVENT_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
+    PARAM_SELECTED_DEVICES,
+    PARAM_WEBHOOK_ID,
+    PARAM_WEBHOOK_URL,
+)
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    app_id = entry.data.get(PARAM_APP_ID, "")
+    webhook_id = entry.data.get(PARAM_WEBHOOK_ID, "")
+    webhook_url = entry.options.get(PARAM_WEBHOOK_URL, "")
+    selected = entry.options.get(PARAM_SELECTED_DEVICES) or entry.data.get(
+        PARAM_SELECTED_DEVICES, []
+    )
+
+    runtime = entry.runtime_data
+    coordinator = runtime.coordinator if runtime is not None else None
+    last_update_success = (
+        coordinator.last_update_success if coordinator is not None else None
+    )
+
+    last_received = (
+        runtime.push_last_received_at.isoformat()
+        if runtime is not None and runtime.push_last_received_at is not None
+        else None
+    )
+
+    event_push = {
+        "enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
+        "webhook_url_configured": bool(webhook_url),
+        "event_push_types": list(entry.options.get(PARAM_EVENT_PUSH_TYPES, [])),
+        "base_push": entry.options.get(PARAM_BASE_PUSH, DEFAULT_BASE_PUSH),
+        "selected_devices_count": len(selected),
+        "recent_msg_type_counts": (
+            dict(runtime.push_msg_type_counts) if runtime is not None else {}
+        ),
+        "last_msg_type": (
+            runtime.push_last_msg_type if runtime is not None else None
+        ),
+        "last_received_at": last_received,
+    }
+
+    return {
+        "app_id": f"{app_id[:4]}…" if len(app_id) > 4 else app_id,
+        "api_url": entry.data.get(PARAM_API_URL),
+        "selected_devices_count": len(selected),
+        "event_push_enabled": bool(entry.options.get(PARAM_ENABLE_EVENT_PUSH)),
+        "webhook_id": f"{webhook_id[:8]}…" if len(webhook_id) > 8 else webhook_id,
+        "webhook_url_configured": bool(webhook_url),
+        "last_update_success": last_update_success,
+        "pyimouapi_version": version("pyimouapi"),
+        "event_push": event_push,
+    }
+```
+
+保留顶层旧字段（`event_push_enabled` 等）以免破坏已有诊断阅读习惯；新细节放在 `event_push` 下。
+
+- [ ] **Step 4: Run tests**
+
+```bash
+uv run pytest tests/test_diagnostics.py tests/test_webhook.py -q --timeout=30
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/imou_life/diagnostics.py tests/test_diagnostics.py
+git commit -m "$(cat <<'EOF'
+feat: expose webhook push msgType stats in diagnostics
+
+EOF
+)"
+```
+
+---
+
+### Task 5: README + CHANGELOG + 全量验证
+
+**Files:**
+- Modify: `README.md`（Troubleshooting 节）
+- Modify: `CHANGELOG.md`（`[1.3.1]` Fixed）
+
+- [ ] **Step 1: Update README Troubleshooting**
+
+将现有 Event push 条目扩展为（保留原有 URL/repair 句，并追加）：
+
+```markdown
+- **Event push not working** — Check **Settings → System → Network → Home Assistant URL** (external URL required), or set a manual callback URL in **Configure**. Review repair issues under **Settings → System → Repairs**.
+  - Automations can listen to `imou_life_event` (all accepted pushes) and `imou_life_alarm` (security alarms only). Privacy-mask messages (`openCamera` / `closeCamera`) fire only `imou_life_event`.
+  - If you receive `abAlarmSound` or `closeCamera`, the callback/webhook path is working.
+  - If `videoMotion` / `human` / `mobileDetect` never appear: confirm motion/human detection is enabled on the device; download **Diagnostics** and check `event_push.recent_msg_type_counts`. Missing keys mean the cloud/device did not push those types (not an HA misclassification).
+  - Confirm event push is enabled in **Configure** and push types include **alarm**.
+```
+
+- [ ] **Step 2: Update CHANGELOG under `[1.3.1]`**
+
+在 `### Changed` 旁增加或合并：
+
+```markdown
+### Fixed
+- Webhook: treat privacy-mask and other status/ops msgTypes (`openCamera`, `closeCamera`, …) as non-alarm (`imou_life_event` only); expose recent push msgType counts in diagnostics (#66)
+```
+
+若 `[1.3.1]` 尚无 `### Fixed`，新建该小节。勿改动无关 sensor changelog 措辞。
+
+- [ ] **Step 3: Full verification**
+
+```bash
+script/lint-check
+script/test
+```
+
+Expected: 全部通过
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: document webhook alarm classification and push diagnostics
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist（自检）
+
+| Spec 要求 | Task |
+|-----------|------|
+| 混合分类 / `openCamera`/`closeCamera` 非报警 | Task 1–2 |
+| 真报警仍发 `imou_life_alarm` | Task 2 |
+| `msg_type is None` 不报警 | Task 1–2 |
+| Runtime 计数 + 50 键上限 | Task 3 |
+| 过滤/关闭 push 不计数 | Task 3 |
+| Diagnostics `event_push` | Task 4 |
+| README 排查 | Task 5 |
+| 不轮询 / 不 getMessageCallback | 全计划未引入 |
+| 事件名/payload 不变 | 全计划未改 normalize 字段 |
+
+## Placeholder scan
+
+无 TBD / “类似 Task N” / 空测试步骤。

--- a/docs/superpowers/specs/2026-07-21-imou-webhook-alarm-classification-design.md
+++ b/docs/superpowers/specs/2026-07-21-imou-webhook-alarm-classification-design.md
@@ -1,0 +1,174 @@
+# Webhook 报警分类与推送可观测性 — 设计规格
+
+**日期:** 2026-07-21  
+**状态:** 已批准  
+**范围:** `Imou-Home-Assistant/custom_components/imou_life`  
+**关联:** [Imou-Home-Assistant#66](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/issues/66)  
+**决策:** 方案 2 — 混合分类 + 本地 runtime 计数 / diagnostics；不轮询、不调用 `getMessageCallback`
+
+## 摘要
+
+修复 webhook 将 `openCamera` / `closeCamera` 等非安防消息误判为 `imou_life_alarm` 的问题；同时用内存计数与 diagnostics 帮助区分「云端未推送」与「收到但分错类」，便于排查动检 / 人形漏推。不改变事件名与 payload 字段，不引入报警轮询兜底。
+
+## 问题陈述
+
+用户（Ranger 2C Pro，海外区，集成 1.3.0）报告：
+
+1. **误分类：** `closeCamera` / `openCamera` 触发了 `imou_life_alarm`（用户认为这不是报警）。
+2. **漏推：** 动检 / 人形未通过 webhook 到达；目前能稳定看到的报警类推送主要是 `abAlarmSound`。
+
+根因（误分类）：`webhook.py` 用黑名单 `_NON_ALARM_TYPES` 判定 `is_alarm = msg_type not in _NON_ALARM_TYPES`，但未包含 `openCamera` / `closeCamera`（官方文档将二者归在 Device alarm 大类，语义为隐私罩开关，不是安防报警）。现有黑名单中的 `"close"` 与实际 `msgType` `"closeCamera"` 也不匹配。
+
+漏推：集成在收到后不会按报警子类型丢弃；若未出现在 HA，更可能是设备未开启或开放平台未推送该 `msgType`。本次通过可观测性支持自证，不保证平台一定推送。
+
+参考：
+
+- [Event message type definition](https://open.imoulife.com/book/en/push/alarm.html)
+- [Event message format definition](https://open.imoulife.com/book/en/push/event.html)
+- [setMessageCallback](https://open.imoulife.com/book/en/http/push/setMessageCallback.html)
+
+## 目标
+
+1. `openCamera` / `closeCamera` 及同类状态/操作消息：只发 `imou_life_event`，不发 `imou_life_alarm`，不触发 notify。
+2. 真报警（`videoMotion`、`human`、`mobileDetect`、`abAlarmSound`、烟感等）：行为与现网一致（推送到达时两者都发）。
+3. diagnostics 可展示近期收到的 `msgType` 计数与本地 push 配置，便于回复 #66。
+4. README 补充 Event push 排查步骤。
+
+## 非目标
+
+- 不实现报警记录轮询兜底
+- 不在 pyimouapi / 本集成中调用 `getMessageCallback`
+- 不保证特定机型一定收到 `videoMotion` / `human`
+- 不改 `callbackFlag` 语义，不新增 push 类型选项
+- 不改 HA core `imou` 组件
+- 不做 breaking change：`imou_life_event` / `imou_life_alarm` 名称与 payload 字段保持不变
+- 计数不持久化、不做成实体
+
+## 架构与数据流
+
+```text
+Imou cloud POST → async_handle_imou_webhook
+  → normalize payload
+  → push_enabled? selected_devices?
+  → record runtime msgType stats
+  → bus.fire(imou_life_event)
+  → if is_alarm_msg_type(msg_type):
+        bus.fire(imou_life_alarm)
+        optional notify
+  → HTTP 200
+```
+
+判定与通知共用同一 `is_alarm` 结果。
+
+## §1 报警分类（混合）
+
+### 规则
+
+```text
+is_alarm = msg_type is not None and msg_type not in NON_ALARM_MSG_TYPES
+```
+
+- 默认：未知 `msgType` **算报警**（避免漏报新安防类型）。
+- `msg_type is None`：**不算报警**（避免脏 payload）。
+
+将现有 `_NON_ALARM_TYPES` 重命名/扩展为 `NON_ALARM_MSG_TYPES`（或等价私有常量），并抽出 `_is_alarm_msg_type(msg_type: str | None) -> bool`，供 handler 与测试使用。常量旁注释指向官方类型文档。
+
+### `NON_ALARM_MSG_TYPES` 至少包含
+
+| 类别 | msgType |
+|------|---------|
+| 设备状态（原有） | `online`, `offline`, `close`, `changeDevName` |
+| IoT / 统计（原有） | `iotEvent`, `iotProperty`, `iotAction`, `numberstat` |
+| 隐私罩（#66） | `openCamera`, `closeCamera` |
+| 灯光 / 警笛状态 | `whiteLightOn`, `whiteLightOff`, `sirenOn`, `sirenOff` |
+| 休眠 | `sleep` |
+| 绑定 / 分享 / 授权 / 转移 | `bindDevice`, `unbindDevice`, `deviceShare`, `deviceShareCancel`, `deviceAuthorize`, `deviceAuthorizationChanged`, `transferDeviceFrom`, `transferDeviceTo`, `deviceDeletedSharedCancel` |
+| 升级 / 存储运维 | `UpgradeSuccess`, `upgradeFail`, `apUpgradeSuccess`, `apUpgradeFail`, `storageRecoverOk`, `storageRecoverFail`, `storageEmpty`, `storageAbnormal` |
+
+**刻意保留为报警（不进黑名单）：** `videoMotion`, `human`, `mobileDetect`, `abAlarmSound`, 以及烟感 / 燃气 / 门磁等安防类。
+
+实现时可按上表一次写入完整 frozenset；后续若 issue 再报误分类，只扩黑名单。
+
+### 事件行为
+
+1. 通过 push 开关与设备过滤后 → 一律 `imou_life_event`
+2. `is_alarm` → 额外 `imou_life_alarm`
+3. `is_alarm` 且配置了 notify → 发通知
+
+## §2 可观测性与文档
+
+### Runtime 计数
+
+在 `ImouRuntimeData` 增加（进程内、不落盘）：
+
+| 字段 | 含义 |
+|------|------|
+| `push_msg_type_counts: dict[str, int]` | 按 `msgType` 累加（含非报警） |
+| `push_last_msg_type: str \| None` | 最近一次成功处理的类型 |
+| `push_last_received_at: datetime \| None` | 最近一次成功处理时间（UTC） |
+
+约束：
+
+- 不同 `msgType` 键数上限 **50**；超出时计入 `"_other"`。
+- 仅在通过 `push_enabled` 与设备过滤之后、准备/已经 `async_fire(EVENT_IMOU_EVENT)` 时更新。
+- push 关闭或设备被过滤：**不计入**。
+
+### Diagnostics
+
+`async_get_config_entry_diagnostics` 增补（脱敏策略不变）：
+
+```text
+event_push:
+  enabled: bool
+  webhook_url_configured: bool
+  event_push_types: list
+  base_push: str
+  selected_devices_count: int
+  recent_msg_type_counts: dict
+  last_msg_type: str | null
+  last_received_at: str | null   # ISO8601 或 null
+```
+
+`runtime_data` 缺失时上述计数字段给空默认值，不抛错。不调用云端 callback 查询 API。
+
+### README
+
+在 Troubleshooting 增加 Event push 要点：
+
+1. 自动化可同时监听 `imou_life_event` 与 `imou_life_alarm`；隐私罩开关只应出现在前者。
+2. 能收到 `abAlarmSound` / `closeCamera` 说明 callback / webhook 通路正常。
+3. 若始终没有 `videoMotion` / `human` / `mobileDetect`：检查设备端动检/人形开关；下载 diagnostics 查看 `recent_msg_type_counts`——若从未出现，属云端/设备未推，非 HA 分类问题。
+4. 确认 Options 中 event push 已启用，且类型包含 `alarm`。
+
+## §3 错误处理与边界
+
+- Webhook 始终 HTTP 200；非法 JSON / 非 dict：不更新计数、不发事件。
+- notify 失败：打日志，不影响事件与 200。
+- 改动文件：`webhook.py`、`runtime_data.py`、`diagnostics.py`、`tests/test_webhook.py`、`tests/test_diagnostics.py`、`README.md`（必要时 `CHANGELOG.md` 在实现计划中单独列出）。
+- 黑名单手工维护，不爬取官方页面。
+
+## 测试计划
+
+| 用例 | 期望 |
+|------|------|
+| `closeCamera` / `openCamera` | 有 `imou_life_event`，无 `imou_life_alarm`，不调 notify |
+| `videoMotion` / `human` / `abAlarmSound` | 两者都有 |
+| `iotProperty` | 保持现有：仅 generic event |
+| `msgType` 缺失 | 发 `imou_life_event`，不发 `imou_life_alarm` |
+| diagnostics | webhook 处理后含 `recent_msg_type_counts` |
+| 未选中设备 / push 关闭 | 无事件、计数不增加 |
+
+## 成功标准
+
+1. #66 描述的误分类在单测与行为上已修复。
+2. 真报警类型在推送到达时行为不变。
+3. diagnostics 能支撑「是否收到某 msgType」的排查。
+4. `script/lint-check` 与 `script/test` 通过。
+
+## 实现顺序（供后续 plan）
+
+1. 扩展 `NON_ALARM_MSG_TYPES` + `_is_alarm_msg_type`，改 handler 判定
+2. Runtime 计数字段 + webhook 更新
+3. Diagnostics 输出
+4. 测试
+5. README（+ 实现阶段再定是否写 CHANGELOG）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ prerelease = "allow"
 [dependency-groups]
 dev = [
   "homeassistant==2025.1.4",
-  "pyimouapi==1.3.1",
+  "pyimouapi==1.3.2",
   "pytest-homeassistant-custom-component==0.13.205",
   "pytest-asyncio>=0.24.0",
   "pytest-timeout>=2.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ prerelease = "allow"
 [dependency-groups]
 dev = [
   "homeassistant==2025.1.4",
-  "pyimouapi==1.2.9",
+  "pyimouapi==1.3.1",
   "pytest-homeassistant-custom-component==0.13.205",
   "pytest-asyncio>=0.24.0",
   "pytest-timeout>=2.3.0",

--- a/releases/v1.2.9.md
+++ b/releases/v1.2.9.md
@@ -1,0 +1,83 @@
+# v1.2.9 — HA best practices, i18n, device selection & event push
+
+**Imou Life v1.2.9** 对齐 Home Assistant 集成最佳实践，升级至 **pyimouapi 1.2.9**，并完善国际化与事件推送。**对现有用户无破坏性变更**（`domain`、实体 `unique_id`、设备标识规则保持不变）。
+
+## ✨ 新功能
+
+- **设备选择**：首次配置与 **Configure → Manage devices** 中可选择要纳入 HA 的设备；未选设备不参与轮询，节省 Open Platform API 配额
+- **事件推送（Webhook）**：可选开启 Imou 云消息回调，支持公网 HA 地址或手动填写回调 URL
+- **自动化事件**
+  - `imou_life_event` — 所有已接受的推送
+  - `imou_life_alarm` — 仅告警类消息
+- **告警通知**：可绑定 notify 服务；推送类型可配置，并同步至 Imou App 或仅 HA 侧处理
+- **完整 i18n**：配置流程、选项页、Webhook 告警文案支持 **英文 / 简体中文**（跟随 HA 语言设置）
+
+## 🔧 改进
+
+- 集成层统一通过 **pyimouapi 1.2.9** 封装 API，不再直接调用 `/openapi/`
+- Coordinator 采用 `devices_by_key`，设备增删可动态热加载，无需整集成重载
+- 事件推送状态由 `ImouRuntimeData` 管理，替代全局 `hass.data`
+- Webhook / 消息回调生命周期独立至 `event_push.py`
+- README 按功能分类更新（账户与选项、事件推送、摄像头 / 传感器 / 插座）
+
+## 🐛 修复
+
+- 兼容新版 HA 的 `async_get_cached_translations()` 签名，修复 Configure 选项页报错
+- Webhook 文案迁至 `webhook_strings/`，通过 Hassfest 校验
+
+## 📍 依赖
+
+- `pyimouapi==1.2.9`
+
+## ⬆️ 升级说明
+
+1. 通过 HACS 更新至 **v1.2.9**
+2. 重启 Home Assistant
+3. 若使用事件推送，在 **Configure** 中确认 Webhook URL 与推送类型
+4. 从旧版升级时，未配置 `webhook_id` 的条目会自动迁移
+
+---
+
+## 🙏 感谢贡献者
+
+| 贡献者 | 贡献 |
+| --- | --- |
+| [@kingkonglua](https://github.com/kingkonglua) | 设备选择与 Webhook 告警推送（[#54](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/pull/54)） |
+| [@Imou-OpenPlatform](https://github.com/Imou-OpenPlatform) | v1.2.9 架构重构、i18n、pyimouapi 集成与 CI 修复（[#61](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/pull/61)）；[pyimouapi 1.2.9](https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api/pull/11) 消息回调与设备摘要 API |
+| [@ZenYao](https://github.com/ZenYao) | 版本合并、代码审查与维护 |
+
+也感谢所有提交 Issue、参与测试和提供反馈的用户。欢迎继续通过 [Issues](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/issues) 参与贡献。
+
+---
+
+<details>
+<summary><strong>English</strong></summary>
+
+**Imou Life v1.2.9** aligns with Home Assistant best practices, upgrades to **pyimouapi 1.2.9**, and improves i18n and event push. **No breaking changes.**
+
+### Added
+
+- **Device selection** at setup and in **Configure → Manage devices**
+- **Event push (webhook)** with public HA URL or manual callback URL
+- HA events: `imou_life_event`, `imou_life_alarm`
+- Optional notify services; configurable push types
+- **Full i18n** (English / Simplified Chinese)
+
+### Changed
+
+- All API calls via **pyimouapi 1.2.9**
+- Coordinator `devices_by_key` with dynamic hot-load
+- `ImouRuntimeData` replaces global `hass.data`
+- Webhook lifecycle in `event_push.py`
+- README reorganized by feature category
+
+### Fixed
+
+- `async_get_cached_translations()` compatibility with newer Home Assistant
+- Webhook strings in `webhook_strings/` for Hassfest
+
+### Acknowledgments
+
+Thanks to [@kingkonglua](https://github.com/kingkonglua), [@Imou-OpenPlatform](https://github.com/Imou-OpenPlatform), and [@ZenYao](https://github.com/ZenYao), plus everyone who reported issues and tested this release.
+
+</details>

--- a/releases/v1.3.0.md
+++ b/releases/v1.3.0.md
@@ -1,0 +1,127 @@
+# Release title
+
+```
+v1.3.0 — Stability, Reauth, Repairs & HA Core Alignment
+```
+
+# Release body
+
+**Imou Life v1.3.0** focuses on stability and Home Assistant integration standards: per-entry webhook isolation, config flow and entity write improvements, plus reauth, repair issues, and diagnostics. **Breaking:** redundant custom entity services removed — use standard HA domain services.
+
+## ✨ Added
+
+- **Reauth flow** — re-authenticate when App Secret expires, without removing and re-adding the integration
+- **Repair issues** — surfaced when event push URL is missing or Imou callback registration fails (**Settings → System → Repairs**)
+- **Diagnostics** — download config entry diagnostics (secrets redacted)
+- **`integration_type: hub`** + **`quality_scale.yaml`** — hub integration with Bronze quality scale
+
+## 🔧 Changed
+
+- **Webhook isolated per config entry** — multiple accounts/regions no longer share runtime state; `runtime_data` is set before event push registration
+- **Config entry v2 migration** — legacy entries automatically receive a `webhook_id` on upgrade
+- **Config flow** — readable entry titles; abort when the device list is empty or unavailable
+- **Entity writes** — switch/select/text changes trigger coordinator refresh; switch types whitelisted
+- **Concurrency** — all platforms declare `PARALLEL_UPDATES = 0`
+
+## 🐛 Fixed
+
+- Unload no longer bulk-removes device registry entries
+- Removed unreliable camera `is_recording` / `is_streaming` properties
+
+## ⚠️ Breaking — automation migration
+
+The following **custom entity services were removed**. Update automations and scripts:
+
+| Removed | Use instead |
+|---------|-------------|
+| `imou_life.turn_on` | `switch.turn_on` |
+| `imou_life.turn_off` | `switch.turn_off` |
+| `imou_life.select` | `select.select_option` |
+| `imou_life.restart_device` | `button.press` (restart button entity) |
+
+Custom service retained: `imou_life.control_move_ptz` (PTZ control).
+
+**Example (YAML automation):**
+
+```yaml
+# Before
+- service: imou_life.turn_on
+  target:
+    entity_id: switch.xxx_motion_detection
+
+# After
+- service: switch.turn_on
+  target:
+    entity_id: switch.xxx_motion_detection
+```
+
+## 📍 Requirements
+
+- Home Assistant **2025.1.0+**
+- `pyimouapi==1.2.9`
+
+## ⬆️ Upgrade
+
+1. Update to **v1.3.0** via HACS (or download `imou_life.zip`)
+2. Restart Home Assistant
+3. Config entry **v1 → v2** migration runs automatically (`webhook_id`)
+4. Review automations/scripts for removed `imou_life.turn_on` and related services
+5. If event push is enabled, verify Webhook / callback URL and push types under **Configure**
+
+---
+
+## 🙏 Acknowledgments
+
+| Contributor | Contribution |
+| --- | --- |
+| [@Imou-OpenPlatform](https://github.com/Imou-OpenPlatform) | v1.3.0 stability refactor, reauth / repairs / diagnostics, HA Core alignment ([#64](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/pull/64)) |
+| [@kingkonglua](https://github.com/kingkonglua) | Webhook event push and device selection ([#54](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/pull/54)) |
+| [@ZenYao](https://github.com/ZenYao) | Code review and maintenance |
+
+Thanks to everyone who filed issues, tested, and provided feedback. Contributions welcome via [Issues](https://github.com/Imou-OpenPlatform/Imou-Home-Assistant/issues).
+
+---
+
+<details>
+<summary><strong>简体中文</strong></summary>
+
+**Imou Life v1.3.0** 聚焦稳定性与 Home Assistant 集成规范对齐：多配置条目 Webhook 隔离、配置流与实体写操作改进，并新增 Reauth、Repair issues 与 Diagnostics。**含破坏性变更**：移除冗余自定义 entity service，请改用 HA 标准服务。
+
+### 新功能
+
+- **Reauth flow** — App Secret 失效时可重新验证，无需删除重配
+- **Repair issues** — 事件推送 URL 缺失或乐橙回调注册失败时在 Repairs 中提示
+- **Diagnostics** — 配置项诊断下载（敏感字段脱敏）
+- **`integration_type: hub`** + **`quality_scale.yaml`**
+
+### 改进
+
+- Webhook 按 config entry 隔离；v2 迁移自动补全 `webhook_id`
+- 配置流可读标题；无设备/拉取失败时中止
+- Switch / Select / Text 写后 refresh；Switch 白名单；`PARALLEL_UPDATES = 0`
+
+### 修复
+
+- Unload 不再批量删除 device registry
+- 移除不可靠的 camera `is_recording` / `is_streaming`
+
+### 破坏性变更
+
+| 已移除 | 请改用 |
+|--------|--------|
+| `imou_life.turn_on` | `switch.turn_on` |
+| `imou_life.turn_off` | `switch.turn_off` |
+| `imou_life.select` | `select.select_option` |
+| `imou_life.restart_device` | `button.press` |
+
+保留：`imou_life.control_move_ptz`。
+
+### 升级说明
+
+1. HACS 更新至 **v1.3.0**
+2. 重启 Home Assistant
+3. 自动 v1→v2 迁移
+4. 检查 automation 中的 `imou_life.*` 服务引用
+5. 确认事件推送 Webhook URL
+
+</details>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,8 +91,12 @@ def setup_imou_runtime(
     entry_data = {**USER_INPUT, "app_id": app_id, PARAM_WEBHOOK_ID: webhook_id}
     entry = MockConfigEntry(domain=DOMAIN, data=entry_data)
     entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    delegate = MagicMock()
+    delegate.async_resolve_event_identifier = AsyncMock(return_value=None)
+    coordinator.device_manager.delegate = delegate
     runtime = ImouRuntimeData(
-        coordinator=MagicMock(),
+        coordinator=coordinator,
         push_enabled=push_enabled,
         selected_devices=selected_devices or [],
         notify_services=notify_services or [],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def setup_imou_runtime(
     runtime = ImouRuntimeData(
         coordinator=coordinator,
         push_enabled=push_enabled,
-        selected_devices=selected_devices or [],
+        selected_devices=selected_devices,
         notify_services=notify_services or [],
     )
     entry.runtime_data = runtime

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from custom_components.imou_life.const import DOMAIN, PARAM_WEBHOOK_ID
+from custom_components.imou_life.const import (
+    DOMAIN,
+    PARAM_BASE_PUSH,
+    PARAM_EVENT_PUSH_TYPES,
+    PARAM_WEBHOOK_ID,
+)
 from custom_components.imou_life.diagnostics import async_get_config_entry_diagnostics
 from custom_components.imou_life.runtime_data import ImouRuntimeData
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -34,3 +39,39 @@ async def test_diagnostics_redacts_secrets(hass) -> None:
     assert result["event_push_enabled"] is True
     assert result["last_update_success"] is True
     assert "pyimouapi_version" in result
+    assert result["event_push"]["enabled"] is True
+    assert result["event_push"]["recent_msg_type_counts"] == {}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_diagnostics_includes_push_msg_counts(hass) -> None:
+    """Diagnostics expose runtime push msgType counters."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**USER_INPUT, PARAM_WEBHOOK_ID: "abcd1234efgh5678"},
+        options={
+            "enable_event_push": True,
+            PARAM_EVENT_PUSH_TYPES: ["alarm", "device_status"],
+            PARAM_BASE_PUSH: "2",
+            "webhook_url": "https://example.com/hook",
+        },
+    )
+    entry.add_to_hass(hass)
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    runtime.record_push_msg("closeCamera")
+    runtime.record_push_msg("abAlarmSound")
+    entry.runtime_data = runtime
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    event_push = result["event_push"]
+
+    assert event_push["enabled"] is True
+    assert event_push["webhook_url_configured"] is True
+    assert event_push["event_push_types"] == ["alarm", "device_status"]
+    assert event_push["base_push"] == "2"
+    assert event_push["recent_msg_type_counts"] == {
+        "closeCamera": 1,
+        "abAlarmSound": 1,
+    }
+    assert event_push["last_msg_type"] == "abAlarmSound"
+    assert event_push["last_received_at"] is not None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock
 import pytest
 from custom_components.imou_life.const import (
     DOMAIN,
-    PARAM_BASE_PUSH,
     PARAM_EVENT_PUSH_TYPES,
     PARAM_WEBHOOK_ID,
 )
@@ -52,7 +51,6 @@ async def test_diagnostics_includes_push_msg_counts(hass) -> None:
         options={
             "enable_event_push": True,
             PARAM_EVENT_PUSH_TYPES: ["alarm", "device_status"],
-            PARAM_BASE_PUSH: "2",
             "webhook_url": "https://example.com/hook",
         },
     )
@@ -68,7 +66,7 @@ async def test_diagnostics_includes_push_msg_counts(hass) -> None:
     assert event_push["enabled"] is True
     assert event_push["webhook_url_configured"] is True
     assert event_push["event_push_types"] == ["alarm", "device_status"]
-    assert event_push["base_push"] == "2"
+    assert event_push["base_push"] == "1"
     assert event_push["recent_msg_type_counts"] == {
         "closeCamera": 1,
         "abAlarmSound": 1,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,11 @@
 """Tests for Imou Life shared helpers and device key helpers."""
 
-from custom_components.imou_life.const import imou_life_device_key_from_ids
+import pytest
+from custom_components.imou_life.const import DOMAIN, imou_life_device_key_from_ids
+from custom_components.imou_life.helpers import resolve_ha_device_name
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 def test_device_key_from_ids_prefers_channel_id() -> None:
@@ -15,3 +20,49 @@ def test_device_key_from_ids_uses_product_when_no_channel() -> None:
 def test_device_key_from_ids_incomplete_returns_none() -> None:
     assert imou_life_device_key_from_ids(None, "0", "pid") is None
     assert imou_life_device_key_from_ids("SN1", None, None) is None
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_resolve_ha_device_name_prefers_name_by_user(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    device = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "SN1_0")},
+        name="Cloud Name",
+    )
+    registry.async_update_device(device.id, name_by_user="Front Door Cam")
+
+    assert (
+        resolve_ha_device_name(hass, "SN1", channel_id="0", product_id="pid")
+        == "Front Door Cam"
+    )
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_resolve_ha_device_name_falls_back_to_name(
+    hass: HomeAssistant,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "SN1_pidX")},
+        name="Plug",
+    )
+
+    assert (
+        resolve_ha_device_name(hass, "SN1", channel_id=None, product_id="pidX")
+        == "Plug"
+    )
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_resolve_ha_device_name_missing_returns_none(
+    hass: HomeAssistant,
+) -> None:
+    assert resolve_ha_device_name(hass, "missing", channel_id="0") is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,17 @@
+"""Tests for Imou Life shared helpers and device key helpers."""
+
+from custom_components.imou_life.const import imou_life_device_key_from_ids
+
+
+def test_device_key_from_ids_prefers_channel_id() -> None:
+    assert imou_life_device_key_from_ids("SN1", "0", "pid") == "SN1_0"
+    assert imou_life_device_key_from_ids("SN1", 0, "pid") == "SN1_0"
+
+
+def test_device_key_from_ids_uses_product_when_no_channel() -> None:
+    assert imou_life_device_key_from_ids("SN1", None, "pidX") == "SN1_pidX"
+
+
+def test_device_key_from_ids_incomplete_returns_none() -> None:
+    assert imou_life_device_key_from_ids(None, "0", "pid") is None
+    assert imou_life_device_key_from_ids("SN1", None, None) is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -128,3 +128,24 @@ async def test_remove_device_without_runtime_refuses(hass) -> None:
 
     assert await async_remove_config_entry_device(hass, entry, device_entry) is False
     assert PARAM_SELECTED_DEVICES not in entry.options
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_remove_device_refuses_empty_coordinator_map(hass) -> None:
+    """Do not materialize an empty allow-list when devices_by_key is empty."""
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
+    entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    coordinator.devices_by_key = {}
+    entry.runtime_data = ImouRuntimeData(coordinator=coordinator, selected_devices=None)
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "d1_0")},
+        serial_number="d1",
+        name="Cam 1",
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, device_entry) is False
+    assert PARAM_SELECTED_DEVICES not in entry.options

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from custom_components.imou_life import async_migrate_entry, async_unload_entry
-from custom_components.imou_life.const import DOMAIN, PARAM_WEBHOOK_ID
+from custom_components.imou_life import (
+    async_migrate_entry,
+    async_remove_config_entry_device,
+    async_unload_entry,
+)
+from custom_components.imou_life.const import (
+    DOMAIN,
+    PARAM_SELECTED_DEVICES,
+    PARAM_WEBHOOK_ID,
+)
 from custom_components.imou_life.runtime_data import ImouRuntimeData
 from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -47,3 +55,76 @@ async def test_unload_keeps_device_registry(hass) -> None:
         assert await async_unload_entry(hass, entry) is True
 
     assert device_registry.async_get(device_entry.id) is not None
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_remove_device_updates_selected_devices(hass) -> None:
+    """Removing a device persists exclusion in options so poll won't re-add it."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={**USER_INPUT, PARAM_SELECTED_DEVICES: ["d1", "d2"]},
+        options={PARAM_SELECTED_DEVICES: ["d1", "d2"]},
+    )
+    entry.add_to_hass(hass)
+    coordinator = MagicMock()
+    coordinator.devices_by_key = {}
+    entry.runtime_data = ImouRuntimeData(
+        coordinator=coordinator, selected_devices=["d1", "d2"]
+    )
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "d1_0")},
+        serial_number="d1",
+        name="Cam 1",
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, device_entry) is True
+    assert entry.options[PARAM_SELECTED_DEVICES] == ["d2"]
+    assert entry.runtime_data.selected_devices == ["d2"]
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_remove_device_materializes_allow_list_when_all_selected(hass) -> None:
+    """When selection means all devices, remove persists remaining ids as allow-list."""
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
+    entry.add_to_hass(hass)
+
+    d1 = MagicMock()
+    d1.device_id = "d1"
+    d2 = MagicMock()
+    d2.device_id = "d2"
+    coordinator = MagicMock()
+    coordinator.devices_by_key = {"d1_0": d1, "d2_0": d2}
+    entry.runtime_data = ImouRuntimeData(coordinator=coordinator, selected_devices=None)
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "d1_0")},
+        serial_number="d1",
+        name="Cam 1",
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, device_entry) is True
+    assert entry.options[PARAM_SELECTED_DEVICES] == ["d2"]
+    assert entry.runtime_data.selected_devices == ["d2"]
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_remove_device_without_runtime_refuses(hass) -> None:
+    """Without runtime, do not rewrite 'all' into an empty allow-list."""
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
+    entry.add_to_hass(hass)
+
+    device_registry = dr.async_get(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "d1_0")},
+        serial_number="d1",
+        name="Cam 1",
+    )
+
+    assert await async_remove_config_entry_device(hass, entry, device_entry) is False
+    assert PARAM_SELECTED_DEVICES not in entry.options

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -254,9 +254,7 @@ async def test_webhook_acks_before_identifier_resolve(hass: HomeAssistant) -> No
     """HTTP 200 must not wait on cold getProductModel resolve."""
     events: list[Event] = []
     hass.bus.async_listen(EVENT_IMOU_EVENT, events.append)
-    runtime = setup_imou_runtime(
-        hass, push_enabled=True, selected_devices=["SN1"]
-    )
+    runtime = setup_imou_runtime(hass, push_enabled=True, selected_devices=["SN1"])
     gate = asyncio.Event()
 
     async def _slow_resolve(_product_id: str, _key: str) -> str | None:

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -311,9 +311,7 @@ async def test_webhook_resolves_numeric_msg_type(hass: HomeAssistant) -> None:
     hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
     hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
 
-    runtime = setup_imou_runtime(
-        hass, push_enabled=True, selected_devices=["device_1"]
-    )
+    runtime = setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
     runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
         AsyncMock(return_value="doorOpen")
     )
@@ -382,9 +380,7 @@ async def test_webhook_skips_resolve_for_string_msg_type(hass: HomeAssistant) ->
     """Non-numeric string msgTypes are not resolved via product model."""
     generic_events: list[Event] = []
     hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
-    runtime = setup_imou_runtime(
-        hass, push_enabled=True, selected_devices=["device_1"]
-    )
+    runtime = setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
     runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
         AsyncMock(return_value="shouldNotMatter")
     )
@@ -407,9 +403,7 @@ async def test_webhook_resolve_failure_keeps_original_msg_type(
     """Resolve errors keep original msg_type and still fire events."""
     generic_events: list[Event] = []
     hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
-    runtime = setup_imou_runtime(
-        hass, push_enabled=True, selected_devices=["device_1"]
-    )
+    runtime = setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
     runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
         AsyncMock(side_effect=RuntimeError("api down"))
     )

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from custom_components.imou_life.const import (
+    DOMAIN,
     EVENT_IMOU_ALARM,
     EVENT_IMOU_EVENT,
 )
@@ -19,6 +20,7 @@ from custom_components.imou_life.webhook import (
     async_handle_imou_webhook,
 )
 from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import setup_imou_runtime
 
@@ -192,6 +194,58 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 
     assert title == "Imou alarm: Local alarm"
     assert message == "Device: Front Door\nType: Local alarm"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_notify_prefers_ha_device_name(hass: HomeAssistant) -> None:
+    """Notify body uses HA device_name over push name."""
+    _title, message = await _async_build_notification_message(
+        hass,
+        {
+            "msg_type": "alarmLocal",
+            "device_name": "HA Front",
+            "name": "Cloud Dname",
+            "device_id": "SN1",
+        },
+    )
+    assert "HA Front" in message
+    assert "Cloud Dname" not in message
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_event_includes_ha_device_name(hass: HomeAssistant) -> None:
+    """Bus events expose registry display name as device_name."""
+    events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_ALARM, events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["SN1"])
+    entry = next(iter(hass.config_entries.async_entries(DOMAIN)))
+    registry = dr.async_get(hass)
+    device = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "SN1_0")},
+        name="Cloud",
+    )
+    registry.async_update_device(device.id, name_by_user="HA Front")
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": "alarmLocal",
+                "deviceId": "SN1",
+                "channelId": "0",
+                "dname": "Cloud Dname",
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(events) == 1
+    assert events[0].data["device_name"] == "HA Front"
+    assert events[0].data["name"] == "Cloud Dname"
+    assert events[0].data["device_id"] == "SN1"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -140,6 +140,24 @@ async def test_webhook_filters_unselected_device(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_empty_selection_rejects_all(hass: HomeAssistant) -> None:
+    """Explicit empty selected_devices must not fall back to accepting all."""
+    events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=[])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "alarmLocal", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert events == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_webhook_iot_property_is_not_alarm(hass: HomeAssistant) -> None:
     """iotProperty push should fire generic event but not alarm event."""
     generic_events: list[Event] = []

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from custom_components.imou_life.const import (
     EVENT_IMOU_ALARM,
     EVENT_IMOU_EVENT,
 )
+from custom_components.imou_life.runtime_data import ImouRuntimeData
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
     _is_alarm_msg_type,
@@ -279,3 +281,67 @@ async def test_webhook_missing_msg_type_is_not_alarm(
     assert response.status == 200
     assert len(generic_events) == 1
     assert alarm_events == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_records_msg_type_counts(hass: HomeAssistant) -> None:
+    """Accepted pushes increment runtime msgType counters."""
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "closeCamera", "deviceId": "device_1"}),
+    )
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "abAlarmSound", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts["closeCamera"] == 2
+    assert runtime.push_msg_type_counts["abAlarmSound"] == 1
+    assert runtime.push_last_msg_type == "abAlarmSound"
+    assert runtime.push_last_received_at is not None
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_filtered_device_does_not_count(
+    hass: HomeAssistant,
+) -> None:
+    """Unselected devices do not update push counters."""
+    runtime = setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["selected_device"],
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "alarmLocal", "deviceId": "other_device"}),
+    )
+    await hass.async_block_till_done()
+
+    assert runtime.push_msg_type_counts == {}
+    assert runtime.push_last_msg_type is None
+
+
+def test_record_push_msg_caps_distinct_keys() -> None:
+    """More than 50 distinct msgTypes fold into _other."""
+    runtime = ImouRuntimeData(coordinator=MagicMock())
+    for i in range(50):
+        runtime.record_push_msg(f"type_{i}")
+    assert len(runtime.push_msg_type_counts) == 50
+    runtime.record_push_msg("type_extra")
+    assert runtime.push_msg_type_counts["_other"] == 1
+    assert "type_extra" not in runtime.push_msg_type_counts
+    assert runtime.push_last_msg_type == "type_extra"

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -14,6 +14,7 @@ from custom_components.imou_life.runtime_data import ImouRuntimeData
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
     _is_alarm_msg_type,
+    _normalize_event_payload,
     async_handle_imou_webhook,
 )
 from homeassistant.core import Event, HomeAssistant
@@ -181,13 +182,18 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
         ("openCamera", False),
         ("online", False),
         ("iotProperty", False),
+        ("iotAction", False),
+        ("iotEvent", True),
         ("whiteLightOn", False),
+        ("sirenOn", True),
+        ("sirenOff", True),
         ("bindDevice", False),
         ("videoMotion", True),
         ("human", True),
         ("abAlarmSound", True),
         ("mobileDetect", True),
         ("alarmLocal", True),
+        ("33000", True),
         ("totallyUnknownType", True),
         (None, False),
     ],
@@ -195,6 +201,67 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
     """Hybrid classification: denylist non-alarms; unknown types are alarms."""
     assert _is_alarm_msg_type(msg_type) is expected
+
+
+def test_normalize_iot_event_promotes_content_fields() -> None:
+    """iotEvent pushes expose content.event as msg_type plus pid/outputData."""
+    event = _normalize_event_payload(
+        {
+            "msgType": "iotEvent",
+            "pid": "mhpf7Dsz",
+            "did": "TESTQWERXXXX",
+            "dname": "Gate",
+            "alarmId": "116257862023505xxxx",
+            "token": "tok",
+            "time": "20230111T111629",
+            "content": {
+                "outputData": {"foo": 1},
+                "event": "33000",
+                "monitor": {"channel": 0, "action": 1},
+            },
+        }
+    )
+
+    assert event["msg_type"] == "33000"
+    assert event["msg_type_name"] == "33000"
+    assert event["product_id"] == "mhpf7Dsz"
+    assert event["device_id"] == "TESTQWERXXXX"
+    assert event["channel_id"] == 0
+    assert event["alarm_id"] == "116257862023505xxxx"
+    assert event["outputData"] == {"foo": 1}
+    assert event["raw"]["msgType"] == "iotEvent"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_iot_event_fires_alarm(hass: HomeAssistant) -> None:
+    """Normalized iotEvent content.event fires imou_life_alarm."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["TESTQWERXXXX"])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": "iotEvent",
+                "pid": "mhpf7Dsz",
+                "did": "TESTQWERXXXX",
+                "dname": "Gate",
+                "content": {"event": "33000", "outputData": {"bar": 2}},
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 1
+    assert alarm_events[0].data["msg_type"] == "33000"
+    assert alarm_events[0].data["product_id"] == "mhpf7Dsz"
+    assert alarm_events[0].data["outputData"] == {"bar": 2}
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -286,9 +286,7 @@ async def test_webhook_missing_msg_type_is_not_alarm(
 @pytest.mark.usefixtures("enable_custom_integrations")
 async def test_webhook_records_msg_type_counts(hass: HomeAssistant) -> None:
     """Accepted pushes increment runtime msgType counters."""
-    runtime = setup_imou_runtime(
-        hass, push_enabled=True, selected_devices=["device_1"]
-    )
+    runtime = setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
 
     await async_handle_imou_webhook(
         hass,

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -246,6 +247,46 @@ async def test_webhook_event_includes_ha_device_name(hass: HomeAssistant) -> Non
     assert events[0].data["device_name"] == "HA Front"
     assert events[0].data["name"] == "Cloud Dname"
     assert events[0].data["device_id"] == "SN1"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_acks_before_identifier_resolve(hass: HomeAssistant) -> None:
+    """HTTP 200 must not wait on cold getProductModel resolve."""
+    events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, events.append)
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["SN1"]
+    )
+    gate = asyncio.Event()
+
+    async def _slow_resolve(_product_id: str, _key: str) -> str | None:
+        await gate.wait()
+        return "human"
+
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
+        AsyncMock(side_effect=_slow_resolve)
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": "33000",
+                "pid": "mhpf7Dsz",
+                "deviceId": "SN1",
+            }
+        ),
+    )
+
+    assert response.status == 200
+    assert events == []
+
+    gate.set()
+    await hass.async_block_till_done()
+
+    assert len(events) == 1
+    assert events[0].data["msg_type"] == "human"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -11,6 +11,7 @@ from custom_components.imou_life.const import (
 )
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
+    _is_alarm_msg_type,
     async_handle_imou_webhook,
 )
 from homeassistant.core import Event, HomeAssistant
@@ -169,3 +170,26 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 
     assert title == "Imou alarm: Local alarm"
     assert message == "Device: Front Door\nType: Local alarm"
+
+
+@pytest.mark.parametrize(
+    ("msg_type", "expected"),
+    [
+        ("closeCamera", False),
+        ("openCamera", False),
+        ("online", False),
+        ("iotProperty", False),
+        ("whiteLightOn", False),
+        ("bindDevice", False),
+        ("videoMotion", True),
+        ("human", True),
+        ("abAlarmSound", True),
+        ("mobileDetect", True),
+        ("alarmLocal", True),
+        ("totallyUnknownType", True),
+        (None, False),
+    ],
+)
+def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
+    """Hybrid classification: denylist non-alarms; unknown types are alarms."""
+    assert _is_alarm_msg_type(msg_type) is expected

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from custom_components.imou_life.const import (
@@ -14,6 +14,7 @@ from custom_components.imou_life.runtime_data import ImouRuntimeData
 from custom_components.imou_life.webhook import (
     _async_build_notification_message,
     _is_alarm_msg_type,
+    _load_webhook_strings_file,
     _normalize_event_payload,
     async_handle_imou_webhook,
 )
@@ -173,6 +174,22 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 
     assert title == "Imou alarm: Local alarm"
     assert message == "Device: Front Door\nType: Local alarm"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_strings_load_via_executor(hass: HomeAssistant) -> None:
+    """Webhook string files must not be read on the event loop (HA blocking I/O)."""
+    _load_webhook_strings_file.cache_clear()
+    with patch.object(
+        hass, "async_add_executor_job", wraps=hass.async_add_executor_job
+    ) as mock_executor:
+        await _async_build_notification_message(
+            hass,
+            {"msg_type": "alarmLocal", "name": "Front Door"},
+        )
+
+    assert mock_executor.call_count >= 1
+    assert mock_executor.call_args.args[0] is _load_webhook_strings_file
 
 
 @pytest.mark.parametrize(

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from custom_components.imou_life.const import (
@@ -200,6 +200,7 @@ async def test_webhook_strings_load_via_executor(hass: HomeAssistant) -> None:
         ("online", False),
         ("iotProperty", False),
         ("iotAction", False),
+        ("electricity", False),
         ("iotEvent", True),
         ("whiteLightOn", False),
         ("sirenOn", True),
@@ -210,7 +211,6 @@ async def test_webhook_strings_load_via_executor(hass: HomeAssistant) -> None:
         ("abAlarmSound", True),
         ("mobileDetect", True),
         ("alarmLocal", True),
-        ("33000", True),
         ("totallyUnknownType", True),
         (None, False),
     ],
@@ -220,8 +220,8 @@ def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
     assert _is_alarm_msg_type(msg_type) is expected
 
 
-def test_normalize_iot_event_promotes_content_fields() -> None:
-    """iotEvent pushes expose content.event as msg_type plus pid/outputData."""
+def test_normalize_iot_event_keeps_top_level_msg_type() -> None:
+    """iotEvent keeps top-level msgType; still exposes pid/outputData/channel."""
     event = _normalize_event_payload(
         {
             "msgType": "iotEvent",
@@ -239,8 +239,8 @@ def test_normalize_iot_event_promotes_content_fields() -> None:
         }
     )
 
-    assert event["msg_type"] == "33000"
-    assert event["msg_type_name"] == "33000"
+    assert event["msg_type"] == "iotEvent"
+    assert event["msg_type_name"] == "iotEvent"
     assert event["product_id"] == "mhpf7Dsz"
     assert event["device_id"] == "TESTQWERXXXX"
     assert event["channel_id"] == 0
@@ -251,7 +251,7 @@ def test_normalize_iot_event_promotes_content_fields() -> None:
 
 @pytest.mark.usefixtures("enable_custom_integrations")
 async def test_webhook_iot_event_fires_alarm(hass: HomeAssistant) -> None:
-    """Normalized iotEvent content.event fires imou_life_alarm."""
+    """Top-level iotEvent fires imou_life_alarm with pid/outputData."""
     generic_events: list[Event] = []
     alarm_events: list[Event] = []
     hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
@@ -276,9 +276,152 @@ async def test_webhook_iot_event_fires_alarm(hass: HomeAssistant) -> None:
     assert response.status == 200
     assert len(generic_events) == 1
     assert len(alarm_events) == 1
-    assert alarm_events[0].data["msg_type"] == "33000"
+    assert alarm_events[0].data["msg_type"] == "iotEvent"
     assert alarm_events[0].data["product_id"] == "mhpf7Dsz"
     assert alarm_events[0].data["outputData"] == {"bar": 2}
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_electricity_is_not_alarm(hass: HomeAssistant) -> None:
+    """electricity pushes fire generic event only."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "electricity", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 0
+    assert generic_events[0].data["msg_type"] == "electricity"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_resolves_numeric_msg_type(hass: HomeAssistant) -> None:
+    """Numeric top-level msgType is rewritten to product-model identifier."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
+        AsyncMock(return_value="doorOpen")
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": "123900",
+                "pid": "pid1",
+                "deviceId": "device_1",
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 1
+    assert generic_events[0].data["msg_type"] == "doorOpen"
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier.assert_awaited_once_with(
+        "pid1", "123900"
+    )
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_resolves_iot_event_content_event(hass: HomeAssistant) -> None:
+    """iotEvent content.event resolves for outbound msg_type; alarm uses iotEvent."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["TESTQWERXXXX"]
+    )
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
+        AsyncMock(return_value="doorOpen")
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": "iotEvent",
+                "pid": "mhpf7Dsz",
+                "did": "TESTQWERXXXX",
+                "content": {"event": "33000"},
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(alarm_events) == 1
+    assert generic_events[0].data["msg_type"] == "doorOpen"
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier.assert_awaited_once_with(
+        "mhpf7Dsz", "33000"
+    )
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_skips_resolve_for_string_msg_type(hass: HomeAssistant) -> None:
+    """Non-numeric string msgTypes are not resolved via product model."""
+    generic_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
+        AsyncMock(return_value="shouldNotMatter")
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "videoMotion", "pid": "pid1", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert generic_events[0].data["msg_type"] == "videoMotion"
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_resolve_failure_keeps_original_msg_type(
+    hass: HomeAssistant,
+) -> None:
+    """Resolve errors keep original msg_type and still fire events."""
+    generic_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    runtime = setup_imou_runtime(
+        hass, push_enabled=True, selected_devices=["device_1"]
+    )
+    runtime.coordinator.device_manager.delegate.async_resolve_event_identifier = (
+        AsyncMock(side_effect=RuntimeError("api down"))
+    )
+
+    await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": "123900", "pid": "pid1", "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert generic_events[0].data["msg_type"] == "123900"
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -193,3 +193,89 @@ async def test_webhook_notification_uses_translations(hass: HomeAssistant) -> No
 def test_is_alarm_msg_type(msg_type: str | None, expected: bool) -> None:
     """Hybrid classification: denylist non-alarms; unknown types are alarms."""
     assert _is_alarm_msg_type(msg_type) is expected
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["closeCamera", "openCamera"])
+async def test_webhook_privacy_mask_is_not_alarm(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Privacy mask open/close fires generic event only."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(
+        hass,
+        push_enabled=True,
+        selected_devices=["device_1"],
+        notify_services=["notify.test"],
+    )
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest(
+            {
+                "msgType": msg_type,
+                "did": "device_1",
+                "cid": 0,
+                "dname": "Cam",
+                "time": 1783528060,
+            }
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert generic_events[0].data["msg_type"] == msg_type
+    assert alarm_events == []
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.parametrize("msg_type", ["videoMotion", "human", "abAlarmSound"])
+async def test_webhook_security_alarms_fire_alarm_event(
+    hass: HomeAssistant, msg_type: str
+) -> None:
+    """Security alarm msgTypes fire both generic and alarm events."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"msgType": msg_type, "deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert len(alarm_events) == 1
+    assert alarm_events[0].data["msg_type"] == msg_type
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_webhook_missing_msg_type_is_not_alarm(
+    hass: HomeAssistant,
+) -> None:
+    """Payload without msgType still fires generic event, not alarm."""
+    generic_events: list[Event] = []
+    alarm_events: list[Event] = []
+    hass.bus.async_listen(EVENT_IMOU_EVENT, generic_events.append)
+    hass.bus.async_listen(EVENT_IMOU_ALARM, alarm_events.append)
+    setup_imou_runtime(hass, push_enabled=True, selected_devices=["device_1"])
+
+    response = await async_handle_imou_webhook(
+        hass,
+        "webhook-id",
+        MockRequest({"deviceId": "device_1"}),
+    )
+    await hass.async_block_till_done()
+
+    assert response.status == 200
+    assert len(generic_events) == 1
+    assert alarm_events == []

--- a/uv.lock
+++ b/uv.lock
@@ -1916,14 +1916,14 @@ wheels = [
 [[package]]
 name = "pyimouapi"
 version = "1.3.1"
-source = { registry = "/home/open/projects/Py-Imou-Open-Api/dist" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "simpleeval" },
 ]
-sdist = { path = "/home/open/projects/Py-Imou-Open-Api/dist/pyimouapi-1.3.1.tar.gz" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/5d/f56fdc7bd6f1399d596d6893a85b401d72e004e3aa053b1ed080057b6db7/pyimouapi-1.3.1.tar.gz", hash = "sha256:9a0eed654a7f10f961bec3ebff37203d0940f7405b1b7c53e3d56a566f578a8b", size = 26750, upload-time = "2026-07-22T01:49:26.544Z" }
 wheels = [
-    { path = "/home/open/projects/Py-Imou-Open-Api/dist/pyimouapi-1.3.1-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/31/6f/fd60433053c1194b5ae710a44376b22dc513c439c28ec91aaa66415ce744/pyimouapi-1.3.1-py3-none-any.whl", hash = "sha256:4ccd2b50fb12153c8ea38d9325f51dc722b6ec41535406c4ddd23f889f1264bb", size = 23001, upload-time = "2026-07-22T01:49:25.424Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1237,7 +1237,7 @@ dev = [
     { name = "codespell", specifier = ">=2.3.0" },
     { name = "homeassistant", specifier = "==2025.1.4" },
     { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pyimouapi", specifier = "==1.2.9" },
+    { name = "pyimouapi", specifier = "==1.3.1" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.205" },
     { name = "pytest-timeout", specifier = ">=2.3.0" },
@@ -1915,15 +1915,15 @@ wheels = [
 
 [[package]]
 name = "pyimouapi"
-version = "1.2.9"
-source = { registry = "https://pypi.org/simple" }
+version = "1.3.1"
+source = { registry = "/home/open/projects/Py-Imou-Open-Api/dist" }
 dependencies = [
     { name = "aiohttp" },
     { name = "simpleeval" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/dd/69add8b71cb0855b1fe0396b77d88275dcc27867cf2c063e999702c2df21/pyimouapi-1.2.9.tar.gz", hash = "sha256:19fc7cac2239c981e5e34843d986d712c6aa19b9adde87474c5fef54c70149d8", size = 23971, upload-time = "2026-07-02T11:51:07.609Z" }
+sdist = { path = "/home/open/projects/Py-Imou-Open-Api/dist/pyimouapi-1.3.1.tar.gz" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/07/707e62b9a389a738eb37523fda3d0e7ab2bfbd9d5d0c0915d37479cb9bd6/pyimouapi-1.2.9-py3-none-any.whl", hash = "sha256:040e6b10ce02fec60a4e4c38235b76b15a448724dd4a8e260d0953e1da7116f0", size = 21172, upload-time = "2026-07-02T11:51:06.369Z" },
+    { path = "/home/open/projects/Py-Imou-Open-Api/dist/pyimouapi-1.3.1-py3-none-any.whl" },
 ]
 
 [[package]]
@@ -2484,8 +2484,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
-    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
+    { name = "audioop-lts" },
+    { name = "standard-chunk" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -1237,7 +1237,7 @@ dev = [
     { name = "codespell", specifier = ">=2.3.0" },
     { name = "homeassistant", specifier = "==2025.1.4" },
     { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "pyimouapi", specifier = "==1.3.1" },
+    { name = "pyimouapi", specifier = "==1.3.2" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.205" },
     { name = "pytest-timeout", specifier = ">=2.3.0" },
@@ -1915,15 +1915,15 @@ wheels = [
 
 [[package]]
 name = "pyimouapi"
-version = "1.3.1"
+version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "simpleeval" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/5d/f56fdc7bd6f1399d596d6893a85b401d72e004e3aa053b1ed080057b6db7/pyimouapi-1.3.1.tar.gz", hash = "sha256:9a0eed654a7f10f961bec3ebff37203d0940f7405b1b7c53e3d56a566f578a8b", size = 26750, upload-time = "2026-07-22T01:49:26.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/b4/9c2f2ce1ced3b614c0b8afc30b3c100209caf8362133458ea09b5f02370a/pyimouapi-1.3.2.tar.gz", hash = "sha256:59add3c984a7af44fece3fc20de9987fdeff93df4846909b2f64148c168c85bf", size = 27443, upload-time = "2026-07-22T05:42:36.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/6f/fd60433053c1194b5ae710a44376b22dc513c439c28ec91aaa66415ce744/pyimouapi-1.3.1-py3-none-any.whl", hash = "sha256:4ccd2b50fb12153c8ea38d9325f51dc722b6ec41535406c4ddd23f889f1264bb", size = 23001, upload-time = "2026-07-22T01:49:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/60/0d5c54806950e2302589e82ea0be53d3cf148857eecf47b5493c5d61a8a0/pyimouapi-1.3.2-py3-none-any.whl", hash = "sha256:6ed916d83718e02bda8c6d639e17652d0467e0d197f69a605991318d1c54017a", size = 23170, upload-time = "2026-07-22T05:42:35.286Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Webhook alarm classification (#66): privacy-mask / status msgTypes as non-alarm; `iotEvent` and related as alarms; msgType diagnostics
- Resolve numeric / `iotEvent` types via pyimouapi product-model identifiers; ACK HTTP 200 before resolve/notify
- Prefer HA device registry name (`device_name`) on events and notify
- Fix `selected_devices` empty-list semantics; close API client on unload; persist UI device removal
- Always sync event push to Imou app (`basePush=1`); depend on `pyimouapi==1.3.2`; bump integration to **1.3.1**

## Test plan
- [ ] Install/reload integration against Imou cloud (login + device list)
- [ ] Webhook: alarm vs privacy-mask / `electricity` / `iotEvent` behavior and notify targets
- [ ] Rename a device in HA → alarm notify uses HA name
- [ ] Empty `selected_devices` polls/accepts none; remove device from UI does not come back on next poll
- [ ] CI green (lint / tests / HACS / manifest versions)