### PR TITLE
docs: surface Configure guides and update record-on-alarm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,8 @@ docs/
 
 # Local release notes drafts (publish via GitHub Releases; use skill imou-ha-release-notes)
 releases/
+
+# Local Home Assistant runtime next to this checkout (never ship)
+log/
+www/
+custom_components/imou_life/config/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ## English
 
-### [Unreleased]
-
-#### Changed
-
-- README leads with the guides (Configure reference, Record on alarm). The install section no longer walks through the old General / Event push wizard or its screenshots; those options live in `guides/configuration.md`
-
 ### [1.4.0]
 
 #### Breaking
@@ -279,12 +273,6 @@
 ---
 
 ## 中文
-
-### [Unreleased]
-
-#### 变更
-
-- README 文首增加文档入口（配置项参考、告警时录像）。安装步骤不再走旧的「常规 / 事件推送」向导和截图；选项说明改在 `guides/configuration.md`
 
 ### [1.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## English
 
+### [Unreleased]
+
+#### Changed
+
+- README leads with the guides (Configure reference, Record on alarm). The install section no longer walks through the old General / Event push wizard or its screenshots; those options live in `guides/configuration.md`
+
 ### [1.4.0]
 
 #### Breaking
@@ -273,6 +279,12 @@
 ---
 
 ## 中文
+
+### [Unreleased]
+
+#### 变更
+
+- README 文首增加文档入口（配置项参考、告警时录像）。安装步骤不再走旧的「常规 / 事件推送」向导和截图；选项说明改在 `guides/configuration.md`
 
 ### [1.4.0]
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ README covers install and a feature list. Options live in the guides:
 | Guide | What it covers |
 | --- | --- |
 | [Configure reference](guides/configuration.md#english) | Every **Configure** page, Home Assistant URL, decrypt libraries, and what depends on what |
-| [Record on alarm](guides/local-event-recording.md#english) | Local clips after an alarm (`camera.record`, allowlist) |
+| [Record on alarm](guides/local-event-recording.md#english) | Built-in short clip after an alarm (no automation); save folder must be allowlisted |
 
 ## Installation
 
@@ -92,7 +92,7 @@ The link yields a zip. After you extract it, the two libraries are under `Open-P
   - Optional alarm notifications: pick Companion App or other notify targets under **Configure → Alarm push and notifications**. Silence one device with **Notify on alarm** on its device page (default on). Companion App: tap opens that camera/accessory's Home Assistant device page
   - Optional **Show the picture in alarm notifications** (default off, **linux x86-64 only**): Home Assistant downloads the encrypted push still and decrypts it locally. [Download the official libraries](#obtain-the-official-decrypt-libraries), then **Configure → Alarm pictures**. Many motion pushes have no picture URL; those stay text-only. Full setup: [Configure reference](guides/configuration.md#english)
   - Choose push message types—including IoT device messages so thing-model switches, sensors, and arming update from property push instead of interval polling; messages are also synced to the Imou Life app
-  - **Record on alarm** — per-camera switch (default off). Shared folder and duration: **Configure → Record on alarm**. Walkthrough: [Record on alarm](guides/local-event-recording.md#english)
+  - **Record on alarm** — built-in: per-camera switch (default off), shared folder and duration under **Configure → Record on alarm**. No YAML automation. Walkthrough: [Record on alarm](guides/local-event-recording.md#english)
 * **Camera**
   - Status (name, online, storage, battery, …)
   - Live video
@@ -134,7 +134,7 @@ The link yields a zip. After you extract it, the two libraries are under `Open-P
 - **Automations after upgrade** — v1.3.0 removes custom `imou_life.turn_on` / `turn_off` / `select` services; use standard `switch.turn_on`, `select.select_option`, and `button.press`. v1.4.0 replaces `select.select_option` on `select.*_mode` with `alarm_control_panel.alarm_arm_home` / `alarm_arm_away` / `alarm_disarm`, and `button.siren_start` / `siren_stop` with `siren.turn_on` / `siren.turn_off`. Leftover `select.*_mode` and siren button registry rows are removed on setup.
 - **PTZ collection points** — use `select.select_option` on `select.<device>_collection_point` with the collection point name (as shown in the Imou Life app). The select shows **Select a collection point…** when the camera is not at a known position.
 - **Diagnostics** — Download redacted diagnostics from the integration's **Download diagnostics** (three-dot menu on the config entry).
-- **Local recording / `camera.record`** — Stream not set up, path access errors, or unavailable camera entities: see [Local event recording](guides/local-event-recording.md#english).
+- **Record on alarm — no file** — confirm event push, the per-camera switch, and an allowlisted save folder: [Record on alarm](guides/local-event-recording.md#english).
 
 ## Contributing
 
@@ -168,7 +168,7 @@ README 只写安装和功能列表。选项说明在 guides 里：
 | 文档 | 内容 |
 | --- | --- |
 | [配置项参考](guides/configuration.md#zh-hans) | 每一个 **配置** 页、Home Assistant 地址、解密库，以及依赖关系 |
-| [告警时录像](guides/local-event-recording.md#zh-hans) | 告警后在本地录短视频（`camera.record`、白名单） |
+| [告警时录像](guides/local-event-recording.md#zh-hans) | 告警后内置短视频（不用写自动化）；保存目录须加入白名单 |
 
 ## 安装
 
@@ -237,7 +237,7 @@ README 只写安装和功能列表。选项说明在 guides 里：
   - 可选告警通知：在 **配置 → 告警推送与通知** 中选择 Companion App 等通知目标；某台不想推可在设备页关掉 **告警时通知**（默认开）。Companion App：点通知打开该设备在 Home Assistant 中的设备页
   - 可选 **在告警通知中显示图片**（默认关，**仅 linux x86-64**）：由 Home Assistant 下载密文并在本机解密。[自行下载官方库](#获取官方解密库)，再打开 **配置 → 告警图片**。许多移动侦测推送没有图片 URL，此时仍为纯文本。完整步骤：[配置项参考](guides/configuration.md#zh-hans)
   - 可选择推送消息类型——含物模型设备消息时，物模型开关 / 传感器 / 布防靠属性推送即时更新，不再跟间隔轮询走；消息也会同步到乐橙 App
-  - **告警时录像** — 每路镜头一个开关（默认关）。保存目录和时长在 **配置 → 告警时录像**。完整步骤：[告警时录像](guides/local-event-recording.md#zh-hans)
+  - **告警时录像** — 内置：每路镜头一个开关（默认关），保存目录和时长在 **配置 → 告警时录像**。不用写 YAML 自动化。完整步骤：[告警时录像](guides/local-event-recording.md#zh-hans)
 * **摄像头**
   - 状态（名称、在线、存储、电量等）
   - 直播
@@ -279,7 +279,7 @@ README 只写安装和功能列表。选项说明在 guides 里：
 - **升级后自动化** — v1.3.0 起移除自定义 `imou_life.turn_on` / `turn_off` / `select` 服务；请使用标准 `switch.turn_on`、`select.select_option`、`button.press`。v1.4.0 起 `select.*_mode` 的 `select.select_option` 改为 `alarm_control_panel.alarm_arm_home` / `alarm_arm_away` / `alarm_disarm`；`button.siren_start` / `siren_stop` 改为 `siren.turn_on` / `siren.turn_off`。遗留的 `select.*_mode` 和警号 button 注册行会在加载时删除。
 - **云台收藏点** — 对 `select.<设备>_collection_point` 使用 `select.select_option`，选项填乐橙 App 中的收藏点名称。当前位置未知时，下拉框显示 **选择收藏点…**。
 - **诊断** — 在集成条目的三点菜单中 **下载诊断**（已脱敏）。
-- **本地录像 / `camera.record`** — Stream 未启用、路径无权访问、相机实体 unavailable 等：见 [本地事件录像](guides/local-event-recording.md#zh-hans)。
+- **告警时录像没有文件** — 确认已开事件推送、该路镜头开关，以及保存目录已加入白名单：见 [告警时录像](guides/local-event-recording.md#zh-hans)。
 
 ## 贡献
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **[English](#english)** | **[简体中文](#zh-hans)**
 
+**Guides / 文档:** [Configure reference / 配置项参考](guides/configuration.md) · [Record on alarm / 告警时录像](guides/local-event-recording.md)
+
 [![HACS Default][hacs-badge]][hacs-url]
 [![GitHub Release][release-badge]][release-url]
 [![HACS Downloads][downloads-badge]][release-url]
@@ -14,6 +16,15 @@
 This integration connects Home Assistant to Imou cameras and smart devices through the Imou Open Platform API: live video, device control, and status. You can extend it with automations and additional features.
 
 > **Open Platform portal:** [open.imoulife.com](https://open.imoulife.com/) — China users, see [简体中文](#zh-hans).
+
+## Documentation
+
+README covers install and a feature list. Options live in the guides:
+
+| Guide | What it covers |
+| --- | --- |
+| [Configure reference](guides/configuration.md#english) | Every **Configure** page, Home Assistant URL, decrypt libraries, and what depends on what |
+| [Record on alarm](guides/local-event-recording.md#english) | Local clips after an alarm (`camera.record`, allowlist) |
 
 ## Installation
 
@@ -39,9 +50,7 @@ Register on [open.imoulife.com](https://open.imoulife.com/), then open **My App*
 
 <img src="assets/images/login_new.png" width="70%" alt="Imou Life login — App ID, App Secret, and server region">
 
-Then select which devices to add. Unselected devices are not polled (saves API quota).
-
-<img src="assets/images/configure_devices.png" width="70%" alt="Select devices during setup">
+Then select which devices to add. Unselected devices stay in Home Assistant but are not polled (saves API quota).
 
 ### 4. Done
 
@@ -49,23 +58,9 @@ Devices under your Imou account should appear in Home Assistant.
 
 <img src="assets/images/integration_overview.png" width="70%" alt="Imou Life integration entry and entities">
 
-Use **Configure** on the integration entry to open a menu: **Polling and cameras**, **Alarm push and notifications**, **Alarm pictures**, **Record on alarm**, **Choose devices to poll**, or **Bind a new device**. The menu leads with a one-line status of what is on. Each section saves when you submit that form and returns to the menu, so you can edit several in one visit; **Done** closes the dialog.
+Use **Configure** on the integration entry. The menu is **Polling and cameras**, **Alarm push and notifications**, **Alarm pictures**, **Record on alarm**, **Choose devices to poll**, and **Bind a new device**. Each page saves and returns to the menu; **Done** closes it.
 
-- **Polling and cameras** — polling on/off and interval. Snapshot wait, live stream, and PTZ defaults are under **Camera defaults**.
-
-<img src="assets/images/configure_general.png" width="70%" alt="Configure — General settings">
-
-- **Alarm push and notifications** — enable the webhook callback, pick message types, and choose notification targets.
-- **Alarm pictures** — turn the decrypted thumbnail on and hold the device passwords it needs. For now you must [download the official decrypt libraries yourself](#obtain-the-official-decrypt-libraries).
-- **Record on alarm** — shared save folder and clip duration for cameras whose **Record on alarm** switch is on. See [guides/local-event-recording.md](guides/local-event-recording.md#english).
-
-Turn on **Enable event push**, then fill **Callback URL** (must be public; change hostname and port if the suggested address is not reachable) and **Subscribe to**.
-
-<img src="assets/images/configure_event_push.png" width="70%" alt="Configure — Event push settings">
-
-- **Choose devices to poll** / **Bind a new device** — pick which devices to poll, or bind a new one by serial; each action saves when you submit
-
-<img src="assets/images/configure_devices.png" width="70%" alt="Configure — Devices">
+Page-by-page options, including the **Settings → System → Network** steps that alarm push and alarm pictures need: [Configure reference](guides/configuration.md#english). Alarm clips: [Record on alarm](guides/local-event-recording.md#english).
 
 >Note: <br>
 >The integration uses the Imou Open Platform for cloud-based remote device access. <br>
@@ -95,10 +90,9 @@ The link yields a zip. After you extract it, the two libraries are under `Open-P
   - **Configure → Alarm push and notifications** — callback URL (suggested URL; replace hostname and port if it is not public), message types, and phone notify.
   - Home Assistant events: `imou_life_event` (all accepted pushes), `imou_life_alarm` (alarm-type only)
   - Optional alarm notifications: pick Companion App or other notify targets under **Configure → Alarm push and notifications**. Silence one device with **Notify on alarm** on its device page (default on). Companion App: tap opens that camera/accessory's Home Assistant device page
-  - Optional **Show the picture in alarm notifications** (default off): Home Assistant downloads the encrypted push picture itself (`thumbUrl` first, then `picUrlArray` / `picUrlArr` / `picUrl`), then decrypts it locally with the official Demo libraries — no Open API quota is spent and no access token is involved. **linux x86-64 only**; [download the official Demo package](#obtain-the-official-decrypt-libraries) and copy `libLCOpenApiClient.so` and `libLCOpenSDK.so` into `/config/imou_life/native/` (the SDK does the decrypting, the client library supplies the OpenSSL symbols it links against). Some devices additionally need their Imou Life device password; **Configure → Alarm pictures** lists exactly those, and takes a **Default device password** for the rest of them. Companion notifications use Home Assistant's **external URL** (Settings → System → Network) so phones outside the LAN can load the JPEG. Add `notify.persistent_notification` to the notify targets to get the same picture in the Home Assistant web notification drawer as well (one entry per device, and it replaces that target's plain text so one alarm never shows up twice). Files live under `/local/imou_life/thumbs/` with no authentication (anyone with the URL can view them for about 24 hours). If `/config/www` did not exist, restart Home Assistant after the first thumbnail. Many motion pushes have no picture URL; then notifications stay text-only
+  - Optional **Show the picture in alarm notifications** (default off, **linux x86-64 only**): Home Assistant downloads the encrypted push still and decrypts it locally. [Download the official libraries](#obtain-the-official-decrypt-libraries), then **Configure → Alarm pictures**. Many motion pushes have no picture URL; those stay text-only. Full setup: [Configure reference](guides/configuration.md#english)
   - Choose push message types—including IoT device messages so thing-model switches, sensors, and arming update from property push instead of interval polling; messages are also synced to the Imou Life app
-  - Push payload alarm images are encrypted. Without the optional thumbnail, no snapshot is attached (Open API quota); use automations with `camera.snapshot` / `camera_proxy` if you need other notification images
-  - **Record on alarm** — per-camera switch (default off, stored in Home Assistant only). When an alarm is pushed, the integration records a short cloud-HLS clip with `camera.record`. Shared folder and duration: **Configure → Record on alarm**. See [guides/local-event-recording.md](guides/local-event-recording.md#english)
+  - **Record on alarm** — per-camera switch (default off). Shared folder and duration: **Configure → Record on alarm**. Walkthrough: [Record on alarm](guides/local-event-recording.md#english)
 * **Camera**
   - Status (name, online, storage, battery, …)
   - Live video
@@ -167,6 +161,15 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before
 
 > **开放平台入口：** [open.imou.com](https://open.imou.com/) — 海外用户请参阅 [English](#english)。
 
+## 文档
+
+README 只写安装和功能列表。选项说明在 guides 里：
+
+| 文档 | 内容 |
+| --- | --- |
+| [配置项参考](guides/configuration.md#zh-hans) | 每一个 **配置** 页、Home Assistant 地址、解密库，以及依赖关系 |
+| [告警时录像](guides/local-event-recording.md#zh-hans) | 告警后在本地录短视频（`camera.record`、白名单） |
+
 ## 安装
 
 在 **Imou 国内开放平台** 注册并创建应用，再通过 HACS 安装。
@@ -191,9 +194,7 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before
 
 <img src="assets/images/login_new.png" width="70%" alt="Imou Life 登录 — App ID、App Secret 与服务器区域">
 
-然后选择要添加的设备。未勾选的设备不会被轮询（可节省 API 配额）。
-
-<img src="assets/images/configure_devices.png" width="70%" alt="安装时选择设备">
+然后选择要添加的设备。未勾选的设备仍留在 Home Assistant，但不会被轮询（可节省 API 配额）。
 
 ### 4. 完成
 
@@ -201,23 +202,9 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before
 
 <img src="assets/images/integration_overview.png" width="70%" alt="Imou Life 集成条目与实体">
 
-在集成条目上点击 **配置** 会打开菜单：**轮询与摄像头**、**告警推送与通知**、**告警图片**、**告警时录像**、**选择要轮询的设备**、**绑定新设备**。菜单开头会给出一行当前状态。每一项提交即保存并回到菜单，一次可以连着改好几项；点 **完成** 关闭对话框。
+在集成条目上点 **配置**。菜单是 **轮询与摄像头**、**告警推送与通知**、**告警图片**、**告警时录像**、**选择要轮询的设备**、**绑定新设备**。每一页提交即保存并回到菜单；点 **完成** 关闭。
 
-- **轮询与摄像头** — 轮询开关与间隔。抓图等待、直播与云台默认参数在 **摄像头默认**。
-
-<img src="assets/images/configure_general.png" width="70%" alt="配置 — 常规设置">
-
-- **告警推送与通知** — 启用 Webhook 回调、选择消息类型、指定通知目标。
-- **告警图片** — 打开解密缩略图开关，并集中管理它需要的设备密码。现阶段需要[自行下载官方解密库](#获取官方解密库)。
-- **告警时录像** — 账号共用的保存目录和片段时长，只对打开了 **告警时录像** 开关的摄像头生效。见 [guides/local-event-recording.md](guides/local-event-recording.md#zh-hans)。
-
-先打开 **启用事件推送**，再确认 **回调地址**（已预填生成的地址，须公网可达；不可达时只改主机名和端口）和 **订阅类型**。
-
-<img src="assets/images/configure_event_push.png" width="70%" alt="配置 — 事件推送设置">
-
-- **选择要轮询的设备** / **绑定新设备** — 勾选要轮询的设备，或按序列号绑定新设备；每一步提交即保存
-
-<img src="assets/images/configure_devices.png" width="70%" alt="配置 — 设备">
+逐页说明，以及告警推送和告警图片都要用的 **设置 → 系统 → 网络**：见 [配置项参考](guides/configuration.md#zh-hans)。告警录像：见 [告警时录像](guides/local-event-recording.md#zh-hans)。
 
 >说明：<br>
 >本集成通过 Imou 开放平台进行云端远程访问。<br>
@@ -248,10 +235,9 @@ Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) before
   - **配置 → 告警推送与通知** — 回调地址（建议地址；不可达时改主机名和端口）、消息类型、手机通知。
   - Home Assistant 事件：`imou_life_event`（所有已接受推送）、`imou_life_alarm`（仅告警类）
   - 可选告警通知：在 **配置 → 告警推送与通知** 中选择 Companion App 等通知目标；某台不想推可在设备页关掉 **告警时通知**（默认开）。Companion App：点通知打开该设备在 Home Assistant 中的设备页
-  - 可选 **在告警通知中显示图片**（默认关）：推送带图片 URL 时（先 `thumbUrl`，再 `picUrlArray` / `picUrlArr` / `picUrl`），由 Home Assistant 自己下载密文图片，再用官方 Demo 库在本机解密——不消耗开放平台配额，也不需要 access token。**仅 linux x86-64**；[自行下载官方 Demo 包](#获取官方解密库)，把 `libLCOpenApiClient.so` 和 `libLCOpenSDK.so` 放到 `/config/imou_life/native/`（`libLCOpenSDK.so` 负责解密，`libLCOpenApiClient.so` 提供它链接的 OpenSSL 符号，两个都要放）。部分设备还需要填写乐橙 App 里的设备密码；**配置 → 告警图片** 会把需要密码的设备列出来，其余留空的可以用 **默认设备密码** 统一填。Companion 通知使用 Home Assistant **外网 URL**（设置 → 系统 → 网络），手机不在局域网也能加载。想在 Home Assistant 网页通知栏也看到这张图，把 `notify.persistent_notification` 加进通知目标（每台设备一条，并顶替该目标的纯文本，同一告警不会出现两条）。文件在 `/local/imou_life/thumbs/`，无身份验证（持有 URL 者约 24 小时内可查看）。若原先没有 `/config/www`，首次生成后需重启 Home Assistant。许多移动侦测推送没有图片 URL，此时通知仍为纯文本
+  - 可选 **在告警通知中显示图片**（默认关，**仅 linux x86-64**）：由 Home Assistant 下载密文并在本机解密。[自行下载官方库](#获取官方解密库)，再打开 **配置 → 告警图片**。许多移动侦测推送没有图片 URL，此时仍为纯文本。完整步骤：[配置项参考](guides/configuration.md#zh-hans)
   - 可选择推送消息类型——含物模型设备消息时，物模型开关 / 传感器 / 布防靠属性推送即时更新，不再跟间隔轮询走；消息也会同步到乐橙 App
-  - 推送载荷中的告警图片为加密格式。未开启可选缩略图时不附带抓图（避免占用开放平台额度）；若需其他通知图片，请在自动化中使用 `camera.snapshot` / `camera_proxy`
-  - **告警时录像** — 每路镜头一个开关（默认关，只存在 Home Assistant）。收到告警推送后，用 `camera.record` 从云端 HLS 录一段短视频。保存目录和时长在 **配置 → 告警时录像**。见 [guides/local-event-recording.md](guides/local-event-recording.md#zh-hans)
+  - **告警时录像** — 每路镜头一个开关（默认关）。保存目录和时长在 **配置 → 告警时录像**。完整步骤：[告警时录像](guides/local-event-recording.md#zh-hans)
 * **摄像头**
   - 状态（名称、在线、存储、电量等）
   - 直播

--- a/custom_components/imou_life/local_record.py
+++ b/custom_components/imou_life/local_record.py
@@ -101,9 +101,9 @@ async def async_maybe_record_from_alarm(
 
     runtime = get_runtime_data(entry)
     if runtime is not None:
-        started = runtime.local_record_started_at.get(device_key, 0.0)
+        started = runtime.local_record_started_at.get(device_key)
         now = hass.loop.time()
-        if now - started < duration:
+        if started is not None and now - started < duration:
             _LOGGER.debug("Skip overlapping local record for %s", device_key)
             return
         runtime.local_record_started_at[device_key] = now

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -86,7 +86,7 @@ On iOS an unexpanded notification shows a small thumbnail — long-press or pull
 | Save folder | Where clips are written, for example `/media/imou`. Must be listed in `allowlist_external_dirs`. Empty means no recording. | empty |
 | Clip duration | Seconds recorded after an alarm, 15–180. Uses live-stream quota. | 60 |
 
-Each camera has its own **Record on alarm** switch on the device page. See [Record on alarm](local-event-recording.md) for the full walkthrough.
+Each camera has its own **Record on alarm** switch on the device page. The integration records on the alarm push itself — no automation. See [Record on alarm](local-event-recording.md#english) for the full walkthrough.
 
 ### Devices
 
@@ -99,7 +99,7 @@ Each camera has its own **Record on alarm** switch on the device page. See [Reco
 
 | To get this | You need |
 | --- | --- |
-| Any alarm automation, notification, picture, or recording | **Enable event push** on, with a Callback URL the Imou cloud can reach |
+| Any alarm notification, picture, recording, or your own automation | **Enable event push** on, with a Callback URL the Imou cloud can reach |
 | A picture in a phone notification | Event push, **Show the picture in alarm notifications**, both `.so` files, a password for the devices the page lists, and an internet-reachable Home Assistant URL |
 | A picture in the web notification drawer | The same, plus `notify.persistent_notification` among the notification targets |
 | A clip after an alarm | Event push, an allowlisted save folder, and the per-camera switch on |
@@ -193,7 +193,7 @@ iOS 上未展开的通知只显示小缩略图，**长按或下拉展开才是�
 | 保存目录 | 片段写到哪里，例如 `/media/imou`。必须在 `allowlist_external_dirs` 中。留空表示不录。 | 空 |
 | 片段时长 | 告警后录制的秒数，15–180。会占用直播配额。 | 60 |
 
-每个摄像头在设备页上都有自己的 **告警时录像** 开关。完整步骤见 [告警时录像](local-event-recording.md#zh-hans)。
+每个摄像头在设备页上都有自己的 **告警时录像** 开关。集成在告警推送时自己录，不用写自动化。完整步骤见 [告警时录像](local-event-recording.md#zh-hans)。
 
 ### 设备
 
@@ -206,7 +206,7 @@ iOS 上未展开的通知只显示小缩略图，**长按或下拉展开才是�
 
 | 想要 | 需要 |
 | --- | --- |
-| 任何告警自动化、通知、图片或录像 | 开启 **启用事件推送**，且回调地址 Imou 云能访问到 |
+| 告警通知、图片、录像，或你自己写的自动化 | 开启 **启用事件推送**，且回调地址 Imou 云能访问到 |
 | 手机通知里带图 | 事件推送、**在告警通知中显示图片**、两个 `.so` 文件、页面上列出的那些设备的密码，以及一个公网可达的 Home Assistant 地址 |
 | 网页通知栏里带图 | 同上，另外把 `notify.persistent_notification` 加进通知目标 |
 | 告警后有录像片段 | 事件推送、一个已加入白名单的保存目录，以及该摄像头的开关已打开 |

--- a/guides/local-event-recording.md
+++ b/guides/local-event-recording.md
@@ -8,7 +8,7 @@
 
 ## English
 
-When an Imou **alarm** is pushed to Home Assistant, cameras whose **Record on alarm** switch is on can save a short MP4 from the **cloud HLS live stream**.
+When an Imou **alarm** is pushed to Home Assistant, cameras whose **Record on alarm** switch is on save a short MP4 from the **cloud HLS live stream**. The integration does this itself — you do not write an automation.
 
 This is **post-event** recording, not an NVR. Dual-lens devices have one switch per channel.
 
@@ -24,92 +24,44 @@ This is **post-event** recording, not an NVR. Dual-lens devices have one switch 
 
 Each recording pulls the cloud live stream and consumes **Open Platform live-view quota**. Check [My Resources](https://open.imoulife.com/consoleNew/resourceManage/myResource) (international) or the China console equivalent.
 
-### Prerequisites
+### Setup
 
-1. **Imou Life** installed; at least one `camera.*` entity.
-2. **Event push** enabled: **Configure → Alarm push and notifications**, include **alarm**, and a reachable HA callback URL.
-3. A **writable** directory listed in `allowlist_external_dirs` (creating a folder alone is not enough).
-4. The **Stream** component. This integration asks Home Assistant to load Stream when available. If logs still say it is not set up, add `stream:` to `configuration.yaml` and restart.
+1. **Enable event push** — **Configure → Alarm push and notifications**, include **alarm**, and a callback URL the Imou cloud can reach. See [Configure reference](configuration.md#english).
+2. **Pick a writable folder** and add it to Home Assistant’s **allowlist_external_dirs** (creating the folder alone is not enough). On Home Assistant OS, `/media/imou` is typical:
 
-### Step 1 — Create a folder and allowlist it
+   ```yaml
+   homeassistant:
+     allowlist_external_dirs:
+       - /media/imou
+   ```
 
-```bash
-mkdir -p /media/imou
-```
+   Merge that into your existing `homeassistant:` block, then restart. Core / development installs should use an absolute path under the config folder instead.
+3. **Configure → Record on alarm** — **Save folder** (same path as the allowlist; leave empty to skip saving) and **Clip duration** (default 60 seconds, range 15–180). These apply to every camera on this account and do not turn recording on by themselves.
+4. On each camera device page, turn on **Record on alarm** (configuration section) for the lenses you want. Default is off so one alarm does not start pulling live streams for every device.
 
-```yaml
-homeassistant:
-  allowlist_external_dirs:
-    - /media/imou
-```
-
-Merge `allowlist_external_dirs` into your existing `homeassistant:` block; do not duplicate the `homeassistant:` key.
-
-On Core / development installs, use an absolute path under your config folder instead of `/media/imou`.
-
-Restart Home Assistant after changing YAML.
-
-### Step 2 — Shared folder and duration
-
-**Settings → Devices & services → Imou Life → Configure → Record on alarm**
-
-- **Save folder** — same path as the allowlist, for example `/media/imou`. Leave empty to disable saving even if a camera switch is on.
-- **Clip duration** — seconds after the alarm (default 60, range 15–180).
-
-These settings apply to every camera on this account. They do not turn recording on by themselves.
-
-### Step 3 — Per-camera switch
-
-On each camera device page, open **Record on alarm** (configuration section) and turn it on for the lenses you want.
-
-Default is off so an alarm does not start pulling live streams for every device.
-
-### Step 4 — Confirm a clip
-
-Wait until the camera entity is not `unavailable`. Trigger a real alarm (or wait for one). A file like `/media/imou/<deviceId>_<channel>_<timestamp>.mp4` should appear.
-
-To test `camera.record` without waiting for a push:
-
-```yaml
-action: camera.record
-target:
-  entity_id: camera.YOUR_CAMERA_ENTITY
-data:
-  filename: /media/imou/test_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4
-  duration: 30
-  lookback: 0
-```
-
-Set `lookback: 0`. Pre-roll is not reliable on cloud HLS.
-
-### Optional — your own automation
-
-The built-in switch already calls `camera.record` on `imou_life_alarm`. Keep a YAML automation only if you need extra filters or a different filename. Use the same allowlisted root.
+After a real alarm, a file like `/media/imou/<deviceId>_<channel>_<timestamp>.mp4` should appear. Wait until the camera entity is not `unavailable`.
 
 ### Limitations
 
 1. **Cloud HLS only** — same source as live preview; latency of several seconds is normal.
 2. **Post-event only** — no dependable pre-alarm buffer without keeping a continuous stream open.
 3. **Quota** — every clip consumes live-stream quota for the AppId.
-4. **Encrypted alarm images** in push payloads need the optional **Show the picture in alarm notifications** (Configure → Alarm pictures), which is linux x86-64 only. Without it, use `camera.snapshot` when you need a still for notifications.
-5. Overlapping alarms on the same camera are skipped until the current clip duration elapses.
+4. Overlapping alarms on the same camera are skipped until the current clip duration elapses.
 
 ### Troubleshooting
 
 | Symptom | What to do |
 | --- | --- |
 | Switch on but no file | Confirm **Configure → Record on alarm** has a folder; confirm event push and **alarm** type; confirm the camera switch is on. |
-| `Stream integration is not set up` | Add `stream:` to `configuration.yaml`, restart. Stream is **not** added via the brand picker. |
-| `Can't write …, no access to path!` | Folder is not under `allowlist_external_dirs`, directory missing, or absolute path mismatch. Fix and restart. Options save is refused until the folder is allowlisted. |
-| `Referenced entities … missing or not currently available` | Wait until the camera state is not `unavailable` after restart; verify entity ID. |
-| No `imou_life_alarm` | Enable event push + **alarm** type; fix external URL; Diagnostics → `event_push.recent_msg_type_counts`. Privacy mask (`openCamera` / `closeCamera`) fires `imou_life_event` only. |
-| Never see `human` / `videoMotion` | Enable picture change / human detection on the device; confirm the cloud actually pushes those types. |
-| Empty / failed MP4 | Stream URL expired, network issue, or quota; retry; check logs around `getLiveStreamInfo` / stream / ffmpeg. |
+| Options save refused / path not allowed | Folder is not under `allowlist_external_dirs`, directory missing, or absolute path mismatch. Fix and restart. |
+| Camera unavailable | Wait until the camera state is not `unavailable` after restart. |
+| No `imou_life_alarm` | Enable event push + **alarm** type; fix the external URL; Diagnostics → `event_push.recent_msg_type_counts`. Privacy mask (`openCamera` / `closeCamera`) fires `imou_life_event` only. |
+| Empty / failed MP4 | Stream URL expired, network issue, or quota; retry; check logs around `getLiveStreamInfo` / stream / ffmpeg. On Home Assistant Core, if logs say Stream is not set up, add `stream:` to `configuration.yaml` and restart. |
 
 ### Related
 
-- [README — Event push & automations](../README.md#features)
-- [Troubleshooting in README](../README.md#troubleshooting)
+- [Configure reference](configuration.md#english)
+- [README](../README.md#english)
 
 ---
 
@@ -117,7 +69,7 @@ The built-in switch already calls `camera.record` on `imou_life_alarm`. Keep a Y
 
 ## 简体中文
 
-乐橙**告警**推送到 Home Assistant 后，打开了 **告警时录像** 开关的摄像头会从**云端 HLS 直播流**保存一段短 MP4。
+乐橙**告警**推送到 Home Assistant 后，打开了 **告警时录像** 开关的摄像头会从**云端 HLS 直播流**保存一段短 MP4。集成自己完成，**不用写自动化**。
 
 这是**事后短视频**，不是 NVR。双目设备按通道各有一个开关。
 
@@ -133,89 +85,41 @@ The built-in switch already calls `camera.record` on `imou_life_alarm`. Keep a Y
 
 每次录制都会拉云端直播，消耗开放平台**直播配额**。请在控制台查看「我的资源」：[国际站](https://open.imoulife.com/consoleNew/resourceManage/myResource) 或中国站对应页面。
 
-### 前置条件
+### 怎么开
 
-1. 已安装 **Imou Life**，且存在 `camera.*` 实体。
-2. 已开启**事件推送**：**配置 → 告警推送与通知**，包含 **alarm**，且回调 URL 可被乐橙云访问。
-3. 有一个**可写**目录，并已写入 `allowlist_external_dirs`（只建文件夹不够）。
-4. **Stream** 组件。本集成会在可用时请求 Home Assistant 加载 Stream。若日志仍提示未启用，在 `configuration.yaml` 增加 `stream:` 后重启。
+1. **打开事件推送** — **配置 → 告警推送与通知**，订阅含 **alarm**，回调地址乐橙云能访问到。见 [配置项参考](configuration.md#zh-hans)。
+2. **准备一个可写目录**，并加入 Home Assistant 的 **allowlist_external_dirs**（只建文件夹不够）。Home Assistant OS 上常用 `/media/imou`：
 
-### 步骤 1 — 创建目录并加入白名单
+   ```yaml
+   homeassistant:
+     allowlist_external_dirs:
+       - /media/imou
+   ```
 
-```bash
-mkdir -p /media/imou
-```
+   把这段**合并**进已有的 `homeassistant:`，然后重启。Core / 开发环境请用配置目录下的绝对路径。
+3. **配置 → 告警时录像** — **保存目录**（与白名单相同；留空则不保存）和 **片段时长**（默认 60 秒，范围 15–180）。这两项对账号下所有摄像头共用，本身不会打开录像。
+4. 在各摄像头设备页打开 **告警时录像**（配置区），只给需要的镜头打开。默认关闭，避免一次告警把账号下所有设备都拉去直播。
 
-```yaml
-homeassistant:
-  allowlist_external_dirs:
-    - /media/imou
-```
-
-请把 `allowlist_external_dirs` **合并**进已有的 `homeassistant:` 段，不要重复写两个 `homeassistant:`。
-
-Core / 开发环境请改用配置目录下的绝对路径，不要照搬 `/media/imou`。
-
-改 YAML 后重启 Home Assistant。
-
-### 步骤 2 — 公用保存目录和时长
-
-**设置 → 设备与服务 → Imou Life → 配置 → 告警时录像**
-
-- **保存目录** — 与白名单相同，例如 `/media/imou`。留空则即使打开了摄像头开关也不会保存。
-- **片段时长** — 告警后录制的秒数（默认 60，范围 15–180）。
-
-这两项对账号下所有摄像头共用，本身不会打开录像。
-
-### 步骤 3 — 每路镜头开关
-
-在各摄像头设备页打开 **告警时录像**（配置区），只给需要的镜头打开。
-
-默认关闭，避免一次告警把账号下所有设备都拉去直播。
-
-### 步骤 4 — 确认生成文件
-
-等待相机实体不是 `unavailable`。触发一次真实告警后，应出现类似 `/media/imou/<deviceId>_<channel>_<时间戳>.mp4` 的文件。
-
-不经过推送、只验证 `camera.record` 时：
-
-```yaml
-action: camera.record
-target:
-  entity_id: camera.YOUR_CAMERA_ENTITY
-data:
-  filename: /media/imou/test_{{ now().strftime('%Y%m%d_%H%M%S') }}.mp4
-  duration: 30
-  lookback: 0
-```
-
-请将 `lookback` 设为 `0`。云端 HLS 无法可靠预录。
-
-### 可选 — 自己写自动化
-
-内置开关已在 `imou_life_alarm` 时调用 `camera.record`。只有需要额外过滤或自定义文件名时才保留 YAML 自动化。路径仍须落在同一白名单目录下。
+真实告警之后应出现类似 `/media/imou/<deviceId>_<channel>_<时间戳>.mp4` 的文件。等相机实体不是 `unavailable` 再测。
 
 ### 限制说明
 
 1. **仅云端 HLS** — 与实时预览同源；数秒级延迟属正常。
 2. **仅事后录** — 不做持续拉流缓冲则无法可靠预录。
 3. **配额** — 每段录像都会消耗该 AppId 的直播配额。
-4. 推送中的**告警图片为加密格式**，需开启可选的**在告警通知中显示图片**（配置 → 告警图片，仅 linux x86-64）才能当缩略图；不开则通知配图请用 `camera.snapshot`。
-5. 同一摄像头在当前片段时长内的重复告警会被跳过。
+4. 同一摄像头在当前片段时长内的重复告警会被跳过。
 
 ### 故障排查
 
 | 现象 | 处理 |
 | --- | --- |
 | 开关已开但没有文件 | 确认 **配置 → 告警时录像** 已填目录；确认已启用事件推送且包含 **alarm**；确认该路镜头开关已开。 |
-| `Stream integration is not set up` | 在 `configuration.yaml` 增加 `stream:` 并重启。Stream **不能**通过「添加集成」品牌列表安装。 |
-| `Can't write …, no access to path!` | 目录不在 `allowlist_external_dirs` 下、文件夹不存在、或绝对路径不一致。修正后重启。未加入白名单时，选项页会拒绝保存。 |
-| `Referenced entities … missing or not currently available` | 重启后等待相机状态非 `unavailable`；核对实体 ID。 |
+| 选项保存被拒 / 路径不在白名单 | 目录不在 `allowlist_external_dirs`、文件夹不存在、或绝对路径不一致。修正后重启。 |
+| 相机不可用 | 重启后等待相机状态非 `unavailable`。 |
 | 收不到 `imou_life_alarm` | 启用事件推送且包含 **alarm**；检查外网 URL；诊断信息中的 `event_push.recent_msg_type_counts`。隐私遮蔽（`openCamera` / `closeCamera`）只触发 `imou_life_event`。 |
-| 始终没有 `human` / `videoMotion` | 在设备上开启画面变化/人形检测；确认云端确实推送了这些类型。 |
-| MP4 为空或失败 | 流地址过期、网络或配额问题；重试；查看 `getLiveStreamInfo` / stream / ffmpeg 相关日志。 |
+| MP4 为空或失败 | 流地址过期、网络或配额问题；重试；查看 `getLiveStreamInfo` / stream / ffmpeg 相关日志。Home Assistant Core 若日志说 Stream 未启用，在 `configuration.yaml` 增加 `stream:` 后重启。 |
 
 ### 相关链接
 
-- [README — 事件推送与自动化](../README.md#zh-hans)
-- [README 故障排查](../README.md#故障排查)
+- [配置项参考](configuration.md#zh-hans)
+- [README](../README.md#zh-hans)

--- a/tests/test_local_event_record.py
+++ b/tests/test_local_event_record.py
@@ -183,6 +183,31 @@ async def test_alarm_records_only_the_armed_camera(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
+async def test_first_record_is_not_skipped_while_loop_time_is_low(
+    hass: HomeAssistant,
+) -> None:
+    """A missing start time must not be treated as loop time 0."""
+    setup_imou_runtime(hass, selected_devices=["SN1"])
+    entry = next(iter(hass.config_entries.async_entries(DOMAIN)))
+    hass.config_entries.async_update_entry(
+        entry,
+        options={
+            PARAM_LOCAL_RECORD_PATH: "/media/imou",
+            PARAM_LOCAL_RECORD_DURATION: 45,
+        },
+    )
+    _register_camera_and_switch(hass, device_key="SN1_0", switch_on=True)
+
+    with (
+        patch.object(hass.config, "is_allowed_path", return_value=True),
+        patch.object(hass.loop, "time", return_value=5.0),
+    ):
+        calls = await _alarm(hass, entry)
+
+    assert len(calls) == 1
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_webhook_alarm_uses_local_record_helper(hass: HomeAssistant) -> None:
     """A security alarm from the webhook records when the camera switch is on."""
     setup_imou_runtime(


### PR DESCRIPTION
## Summary
- Point the README at `guides/configuration.md` and `guides/local-event-recording.md` (top of the page, plus a Documentation section).
- Drop the old General / Event push wizard screenshots from install; options live in the Configure reference.
- Rewrite Record on alarm as a built-in option (event push + folder + switch). No YAML automation.
- Ignore local HA runtime dirs (`log/`, `www/`, decrypt `config/`) next to the checkout.

## Test plan
- [ ] GitHub README on this PR shows **Guides / 文档** links
- [ ] `guides/configuration.md` and `guides/local-event-recording.md` open from those links
- [ ] Record-on-alarm guide does not tell users to write a `camera.record` automation